### PR TITLE
Develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ ltr3.png
 8x32 iMAGE.xcf
 
 .vscode/c_cpp_properties.json
+.vs/

--- a/README.md
+++ b/README.md
@@ -527,6 +527,8 @@ ehmtxv2:
 
 **scroll_small_text** (optional, bool): normally small text is centered on the display if possible, with this set to `true` even small text is scrolled in `text_screen` and `rainbow_text_screen` (default: false)
 
+**allow_empty_screen** (optional, bool): When the queue for messages to be displayed is empty and the time screen has been removed, the time screen is normally reactivated. This option can be used to disable this behavior by setting `allow_empty_screen` to `true`. (default: false)
+
 **rtl** (optional, boolean): if `true` write text (but only the scroll direction, the words and numbers aren't changed!) from right to left (Arabic, Hebrew etc.). Default is `false`
 
 **matrix_component** (required, ID): ID of the addressable display

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -538,11 +538,7 @@ namespace esphome
         }
         else
         {
-          if(EHMTXv2_ALLOW_EMPTY_SCREEN)
-          {
-            ESP_LOGW(TAG, "tick: nothing to do.");
-          }
-          else
+          if(!EHMTXv2_ALLOW_EMPTY_SCREEN)
           {
             ESP_LOGW(TAG, "tick: nothing to do. Restarting clock display!");
             this->clock_screen(24 * 60, this->clock_time, false, C_RED, C_GREEN, C_BLUE);

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -538,10 +538,17 @@ namespace esphome
         }
         else
         {
-          ESP_LOGW(TAG, "tick: nothing to do. Restarting clock display!");
-          this->clock_screen(24 * 60, this->clock_time, false, C_RED, C_GREEN, C_BLUE);
-          this->date_screen(24 * 60, (int)this->clock_time / 2, false, C_RED, C_GREEN, C_BLUE);
-          this->next_action_time = ts + this->clock_time;
+          if(EHMTXv2_ALLOW_EMPTY_SCREEN)
+          {
+            ESP_LOGW(TAG, "tick: nothing to do.");
+          }
+          else
+          {
+            ESP_LOGW(TAG, "tick: nothing to do. Restarting clock display!");
+            this->clock_screen(24 * 60, this->clock_time, false, C_RED, C_GREEN, C_BLUE);
+            this->date_screen(24 * 60, (int)this->clock_time / 2, false, C_RED, C_GREEN, C_BLUE);
+            this->next_action_time = ts + this->clock_time;
+          }
         }
       }
     }

--- a/components/ehmtxv2/__init__.py
+++ b/components/ehmtxv2/__init__.py
@@ -135,7 +135,7 @@ EHMTX_SCHEMA = cv.Schema({
         CONF_SCROLL_SMALL_TEXT, default=False
     ): cv.boolean,
     cv.Optional(
-        CONF_ALLOW_EMPTY_SCREEN, default=True
+        CONF_ALLOW_EMPTY_SCREEN, default=False
     ): cv.boolean,
     cv.Optional(
         CONF_TIME_FORMAT, default="%H:%M"

--- a/components/ehmtxv2/__init__.py
+++ b/components/ehmtxv2/__init__.py
@@ -93,6 +93,7 @@ CONF_ON_ADD_SCREEN = "on_add_screen"
 CONF_ON_EXPIRED_SCREEN= "on_expired_screen"
 CONF_SHOW_SECONDS = "show_seconds"
 CONF_SCROLL_SMALL_TEXT = "scroll_small_text"
+CONF_ALLOW_EMPTY_SCREEN = "allow_empty_screen"
 CONF_WEEK_START_MONDAY = "week_start_monday"
 CONF_ICON = "icon_name"
 CONF_TEXT = "text"
@@ -132,6 +133,9 @@ EHMTX_SCHEMA = cv.Schema({
     ): cv.boolean,
     cv.Optional(
         CONF_SCROLL_SMALL_TEXT, default=False
+    ): cv.boolean,
+    cv.Optional(
+        CONF_ALLOW_EMPTY_SCREEN, default=True
     ): cv.boolean,
     cv.Optional(
         CONF_TIME_FORMAT, default="%H:%M"
@@ -387,6 +391,7 @@ async def to_code(config):
     cg.add_define("EHMTXv2_DATE_FORMAT",config[CONF_DATE_FORMAT])    
     cg.add_define("EHMTXv2_TIME_FORMAT",config[CONF_TIME_FORMAT])    
     cg.add_define("EHMTXv2_SCROLL_SMALL_TEXT",config[CONF_SCROLL_SMALL_TEXT])    
+    cg.add_define("EHMTXv2_ALLOW_EMPTY_SCREEN",config[CONF_ALLOW_EMPTY_SCREEN])
 
     if config[CONF_RTL]:
         cg.add_define("EHMTXv2_USE_RTL")    


### PR DESCRIPTION
Hi,
Vielen Dank für das Hinzufügen des dauerhaft scrollenden Textes.

Ich habe das Problem, dass die standard Uhr immer wieder aktiviert wird, wenn man die Uhr als scrollenden Text anzeigen möchte.

Deshalb habe ich einen Switch (allow_empty_screen) hinzu gefügt, der es erlaubt einfach nichts anzuzeigen.
Im standard ist diese Option auf false, damit die Konfigurationen nicht geändert werden müssen und sich alles wie bisher verhält.