### PR TITLE
Improve blueprint device selection

### DIFF
--- a/copy2esphome/EHMTX_easy_delete.yaml
+++ b/copy2esphome/EHMTX_easy_delete.yaml
@@ -8,7 +8,9 @@ blueprint:
       name: Which EspHoMaTriXv2 device to use
       selector:
         device:
-          integration: esphome
+          filter:
+          - integration: esphome
+            model: EHMTXv2
     trigger_sensor:
       name: Which state change triggers the automation?
       selector:

--- a/copy2esphome/EHMTX_easy_hide.yaml
+++ b/copy2esphome/EHMTX_easy_hide.yaml
@@ -5,10 +5,12 @@ blueprint:
   domain: automation
   input:
     ehmtx_device:
-      name: Which display to use
+      name: Which EspHoMaTriXv2 device to use
       selector:
         device:
-          integration: esphome
+          filter:
+          - integration: esphome
+            model: EHMTXv2
     trigger_sensor:
       name: Which state change triggers this automation
       selector:

--- a/copy2esphome/EHMTX_easy_show.yaml
+++ b/copy2esphome/EHMTX_easy_show.yaml
@@ -5,10 +5,12 @@ blueprint:
   domain: automation
   input:
     ehmtx_device:
-      name: Which device to display at?
+      name: Which EspHoMaTriXv2 device to use
       selector:
         device:
-          integration: esphome
+          filter:
+          - integration: esphome
+            model: EHMTXv2
     trigger_sensor:
       name: Which state-change triggers the screen element
       selector:

--- a/copy2esphome/EHMTX_easy_state.yaml
+++ b/copy2esphome/EHMTX_easy_state.yaml
@@ -5,10 +5,12 @@ blueprint:
   domain: automation
   input:
     ehmtx_device:
-      name: Which EspHoMaTriX-device to display at?
+      name: Which EspHoMaTriXv2 device to use
       selector:
         device:
-          integration: esphome
+          filter:
+          - integration: esphome
+            model: EHMTXv2
     trigger_sensor:
       name: Which sensor state to show?
       description: This sensor state will be displayed.

--- a/copy2esphome/EHMTX_extended_state.yaml
+++ b/copy2esphome/EHMTX_extended_state.yaml
@@ -5,10 +5,12 @@ blueprint:
   domain: automation
   input:
     ehmtx_device:
-      name: Which EspHoMaTriX-device to display at?
+      name: Which EspHoMaTriXv2 device to use
       selector:
         device:
-          integration: esphome
+          filter:
+          - integration: esphome
+            model: EHMTXv2
     trigger_sensor:
       name: Which sensor state to show?
       description: This sensor state will be displayed.

--- a/copy2esphome/ulanzi-easy.yaml
+++ b/copy2esphome/ulanzi-easy.yaml
@@ -59,6 +59,9 @@ external_components:
 esphome:
   comment: "EHMTXv2 from LuBeDa"
   name: $devicename 
+  project:
+    name: "Ulanzi.EHMTXv2"
+    version: "2.0.0"
   on_boot:
     then:
       - ds1307.read_time:


### PR DESCRIPTION
Added a Manufacturer (Ulanzi) and Model (EHMTXv2) within the ESPHome Project Name 
Added filtering on the blueprints to only show EspHome devices with model of EHMTXv2 
Also made device name selection consistent on all blueprints