### PR TITLE
fix value dependent color usage

### DIFF
--- a/copy2esphome/EHMTX_easy_state.yaml
+++ b/copy2esphome/EHMTX_easy_state.yaml
@@ -99,6 +99,7 @@ blueprint:
 variables:
   display: !input ehmtx_device
   bfriendly: !input use_friendly
+  use_colors: !input use_colors
   def_color: !input default_color
   lo_color: !input low_color
   hi_color: !input high_color


### PR DESCRIPTION
This PR simply adds a variable for the input value _use_colors_ to be used in the if/then check later on. Otherwise the input value will be ignored, resulting in the condition to render true and only the default color will be used regardless of the setting.