### PR TITLE
2023.9.1: Screen ID, Progress screen, Icon with Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,6 +730,7 @@ Numerous features are accessible with services from home assistant and lambdas t
 |`icon_clock`|"icon_name", "lifetime", "screen_time", "default_font", "r", "g", "b"|show the specified icon with time, there is support for [displaying text on top of the icon](#icon_text)|
 |`icon_date`|"icon_name", "lifetime", "screen_time", "default_font", "r", "g", "b"|show the specified icon with date, there is support for [displaying text on top of the icon](#icon_text)|
 |`graph_screen`|lifetime", "screen_time"|show graph as defined in the YAML file|
+|`set_infotext_color`|"left_r", "left_g", "left_b", "right_r", "right_g", "right_b"|set the special color for left and right char on info text|
 
 #### Parameter description
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@
 [![Donate][donation-badge]][donation-url]
 [![Publish wiki](https://github.com/lubeda/EspHoMaTriXv2/actions/workflows/wiki.yaml/badge.svg)](https://github.com/lubeda/EspHoMaTriXv2/actions/workflows/wiki.yaml)
 [![Build](https://github.com/lubeda/EspHoMaTriXv2/actions/workflows/main.yml/badge.svg)](https://github.com/lubeda/EspHoMaTriXv2/actions/workflows/main.yml)
+[![StandWithUkraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md)
+
+### EspHoMaTriX 2023.9.1
+- Added the ability to specify a screen ID - `icon_name|screen_id`
+- Added icon and date output screen - `icon_date(iconname, lifetime, screen_time, default_font, r, g, b)`
+- If pass a screen identifier with the value `[day, weekday]` like `icon_name|day`, and a backing icon to `icon_clock` or `icon_date`, it will display text.
+- Added a screen with the ability to display a progress bar, progress value `(-100..100)` - `icon_screen_progress(iconname, text, progress, lifetime, screen_time, default_font, r, g, b)`
+
+### EspHoMaTriX 2023.9.0
+- Added the ability to display graph as defined in the YAML file
+
+### EspHoMaTriX 2023.8.0
+- Added icon and time output screen - `icon_clock(iconname, lifetime, screen_time, default_font, r, g, b)`
+- Added alert screen - `alert_screen(iconname, text, screen_time, default_font, r, g, b)`
 
 ## Attention
 
@@ -36,7 +50,7 @@ The `on_start_runnig`-trigger is called after the device boot once. The `on_empt
 
 If you don't add this trigger you have a blank display until your hosts add screens via service calls.
 
-### esphome 2023.7.0
+### ESPHome 2023.7.0
 
 Some updates of esphome will interfere with EspHoMaTriXv2, like the update of esphome to 2023.7.0. It made a change to all YAML files necessary.
 
@@ -711,18 +725,24 @@ Numerous features are accessible with services from home assistant and lambdas t
 |`blank_screen`|"lifetime", "screen_time"|"show" an empty screen|
 |`date_screen`|"lifetime", "screen_time", "default_font", "r", "g", "b"|show the date|
 |`brightness`|"value"|set the display brightness|
+|`alert_screen`|"icon_name", "text", "screen_time", "default_font", "r", "g", "b"|show the specified icon with text, screen forced and lifetime = screen_time|
+|`icon_screen_progress`|"icon_name", "text", "progress", "lifetime", "screen_time", "default_font", "r", "g", "b"|show the specified icon with text and with progress bar on bottom|
+|`icon_clock`|"icon_name", "lifetime", "screen_time", "default_font", "r", "g", "b"|show the specified icon with time, there is support for [displaying text on top of the icon](#icon_text)|
+|`icon_date`|"icon_name", "lifetime", "screen_time", "default_font", "r", "g", "b"|show the specified icon with date, there is support for [displaying text on top of the icon](#icon_text)|
+|`graph_screen`|lifetime", "screen_time"|show graph as defined in the YAML file|
 
 #### Parameter description
 
-"r", "g", "b": Color components for red, green, and blue 0..255
-"size": The size of the rindicator or alarm, 1-3
-"percent": values from 0..100
-"icon_name": the id of the icon to show, as defined in the YAML file
-"text": a text message to display
-"lifetime": how long does this screen stay in the queue (minutes)
-"screen_time": how long is this screen display in the loop (seconds). For short text without scrolling it is shown the defined time, longer text is scrolled at least `scroll_count` times.
-"default_font": use the default font (true) or the special font (false)
-"value": the brightness 0..255 
+- **r, g, b**: Color components for red, green, and blue 0..255
+- **size**: The size of the rindicator or alarm, 1-3
+- **percent**: values from 0..100
+- **icon_name**: the id of the icon to show, as defined in the YAML file, it is also possible to set the arbitrary [screen identifier](#screen_id), for example `icon_name|screen_id`
+- **text**: a text message to display
+- **lifetime**: how long does this screen stay in the queue (minutes)
+- **screen_time**: how long is this screen display in the loop (seconds). For short text without scrolling it is shown the defined time, longer text is scrolled at least `scroll_count` times.
+- **default_font**: use the default font (true) or the special font (false)
+- **progress**: сan take a value from -100 to 100, the color of the progress bar is calculated automatically, if the progress is in the range `0..100`, then `from red to green`, if in the range `-100..0`, then from `green to red`.
+- **value**: the brightness 0..255 
 
 ### Local lambdas
 
@@ -957,6 +977,8 @@ For example, if you have multiple icons named weather_sunny, weather_rain & weat
 |MODE_ICON_CLOCK| 15|
 |MODE_ALERT_SCREEN| 16|
 |MODE_GRAPH_SCREEN | 17|
+|MODE_ICON_DATE | 18|
+|MODE_ICON_PROGRESS | 19|
 
 **(D)** Service **display_on** / **display_off**
 
@@ -1032,6 +1054,47 @@ This service displays the running queue and a list of icons in the logs
 [13:10:10][I][EHMTX:186]: status icon: 3 name: wind
 [13:10:10][I][EHMTX:186]: status icon: 4 name: rain
 ```
+
+## Advanced options
+
+##### screen_id
+
+Screen identifier allows you to display the same icons on the same screen type without overlapping each other, for example, weather and weather forecast:
+```yaml
+- service: esphome.esp_pixel_clock_icon_screen
+  data:
+    icon_name: "weather_{{ states('weather.current_weather') | replace('-','_') }}|weather"
+...
+- service: esphome.esp_pixel_clock_icon_screen
+  data:
+    icon_name: "weather_{{ states('weather.forecast_weather') | replace('-','_') }}|forecast"
+...
+```
+If the screen identifier is specified, then all work on identification of the screen is carried out by it, as well as in functions like `del_screen`, `force_screen` it **will be necessary to specify it** and **not the name of the icon**.
+
+##### icon_text
+
+A common format for specifying output options: `icon|mode#draw_mode`
+- `icon` - Icon from YAML that will be displayed
+- `mode` - Mode, what will be displayed on the icon
+- `draw_mode` - Mode how the text will be displayed on the icon
+
+**mode** that are supported:
+- `day` - Displays the current day of the month on the icon
+- `weekday` - Displays the current day of the week on the icon 
+
+**draw_mode** that are supported:
+- 0 - default - left and right - baseline from font
+- 1 - center - baseline from font
+- 2 - center - right - baseline from font
+- 3 - left and right - baseline 7
+- 4 - center - baseline 7
+- 5 - center - right - baseline 7
+
+https://github.com/lubeda/EspHoMaTriXv2/issues/92
+
+**Example**: `calendar|day#1` - Show the calendar icon, display the current day of the month on it with the numbers centered.
+
 
 ## Integration in Home Assistant
 

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -802,7 +802,7 @@ namespace esphome
   
   void EHMTX::alert_screen(std::string iconname, std::string text, int screen_time, bool default_font, int r, int g, int b)
   {
-    uint8_t icon = this->find_icon(icon_name.c_str());
+    uint8_t icon = this->find_icon(iconname.c_str());
 
     if (icon >= this->icon_count)
     {
@@ -810,7 +810,7 @@ namespace esphome
       icon = 0;
       for (auto *t : on_icon_error_triggers_)
       {
-        t->process(icon_name);
+        t->process(iconname);
       }
     }
     EHMTX_queue *screen = this->find_mode_queue_element(MODE_ALERT_SCREEN);
@@ -820,7 +820,7 @@ namespace esphome
     screen->text_color = Color(r, g, b);
     screen->default_font = default_font;
     screen->mode = MODE_ALERT_SCREEN;
-    screen->icon_name = icon_name;
+    screen->icon_name = iconname;
     screen->icon = icon;
     screen->calc_scroll_time(text, screen_time);
     // time needed for scrolling
@@ -829,10 +829,10 @@ namespace esphome
     {
       t->process(screen->icon_name, (uint8_t)screen->mode);
     }
-    ESP_LOGD(TAG, "alert screen icon: %d iconname: %s text: %s screen_time: %d", icon, icon_name.c_str(), text.c_str(), screen_time);
+    ESP_LOGD(TAG, "alert screen icon: %d iconname: %s text: %s screen_time: %d", icon, iconname.c_str(), text.c_str(), screen_time);
     screen->status();
 
-    force_screen(icon_name, MODE_ALERT_SCREEN);
+    force_screen(iconname, MODE_ALERT_SCREEN);
   }
 
   void EHMTX::icon_screen(std::string iconname, std::string text, int lifetime, int screen_time, bool default_font, int r, int g, int b)

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -423,11 +423,18 @@ namespace esphome
 
   void EHMTX::set_clock_color(int r, int g, int b)
   {
-    this->clock_color = Color((uint8_t)r , (uint8_t)g , (uint8_t)b );
-    this->del_screen("*", 3);
-    this->del_screen("*", 2);
-    this->clock_screen(24 * 60, this->clock_time, false, this->clock_color[0], this->clock_color[1], this->clock_color[2]);
-    this->date_screen(24 * 60, (int)this->clock_time / 2, false, this->clock_color[0], this->clock_color[1], this->clock_color[2]);
+    this->clock_color = Color((uint8_t)r, (uint8_t)g, (uint8_t)b);
+
+    for (size_t i = 0; i < MAXQUEUE; i++)
+    {
+      if (this->queue[i]->mode == MODE_CLOCK ||
+          this->queue[i]->mode == MODE_DATE ||
+          this->queue[i]->mode == MODE_ICON_CLOCK ||
+          this->queue[i]->mode == MODE_ICON_DATE)
+      {
+        this->queue[i]->text_color = this->clock_color;
+      }
+    }
     ESP_LOGD(TAG, "default clock color r: %d g: %d b: %d", r, g, b);
   }
 

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -15,6 +15,8 @@ namespace esphome
     this->icon_count = 0;
     this->hue_ = 0;
     this->rainbow_color = Color(CA_RED, CA_GREEN, CA_BLUE);
+    this->info_lcolor = Color(CG_GREY, CG_GREY, CG_GREY);
+    this->info_rcolor = Color(CG_GREY, CG_GREY, CG_GREY);
     this->next_action_time = 0;
     this->last_scroll_time = 0;
     this->screen_pointer = MAXQUEUE;
@@ -358,6 +360,7 @@ namespace esphome
     register_service(&EHMTX::set_weekday_color, "set_weekday_color", {"r", "g", "b"});
     register_service(&EHMTX::set_clock_color, "set_clock_color", {"r", "g", "b"});
     register_service(&EHMTX::set_text_color, "set_text_color", {"r", "g", "b"});
+    register_service(&EHMTX::set_infotext_color, "set_infotext_color", {"left_r", "left_g", "left_b", "right_r", "right_g", "right_b"});
 
     register_service(&EHMTX::del_screen, "del_screen", {"icon_name", "mode"});
     register_service(&EHMTX::force_screen, "force_screen", {"icon_name", "mode"});
@@ -440,8 +443,15 @@ namespace esphome
 
   void EHMTX::set_text_color(int r, int g, int b)
   {
-    this->text_color = Color((uint8_t)r , (uint8_t)g , (uint8_t)b );
+    this->text_color = Color((uint8_t)r, (uint8_t)g, (uint8_t)b);
     ESP_LOGD(TAG, "default text color r: %d g: %d b: %d", r, g, b);
+  }
+
+  void EHMTX::set_infotext_color(int lr, int lg, int lb, int rr, int rg, int rb)
+  {
+    this->info_lcolor = Color((uint8_t)lr, (uint8_t)lg, (uint8_t)lb);
+    this->info_rcolor = Color((uint8_t)rr, (uint8_t)rg, (uint8_t)rb);
+    ESP_LOGD(TAG, "info text color left: r: %d g: %d b: %d right: r: %d g: %d b: %d", lr, lg, lb, rr, rg, rb);
   }
 
   void EHMTX::update() // called from polling component

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -1,4 +1,5 @@
 #include "esphome.h"
+#include <sstream>
 
 namespace esphome
 {
@@ -186,6 +187,40 @@ namespace esphome
   }
 #endif
 
+  std::string get_icon_name(std::string iconname, char delim = '|')
+  {
+    std::stringstream stream(iconname);
+    std::string icon;
+    std::vector<std::string> tokens;
+      
+    while (std::getline(stream, icon, delim))
+    {
+      if (!icon.empty())
+      {
+        tokens.push_back(icon);
+      }
+    }
+
+    return (tokens.size() > 0) ? tokens[0] : "";
+  }
+
+  std::string get_screen_id(std::string iconname, char delim = '|')
+  {
+    std::stringstream stream(iconname);
+    std::string screen_id;
+    std::vector<std::string> tokens;
+    
+    while (std::getline(stream, screen_id, delim))
+    {
+      if (!screen_id.empty())
+      {
+        tokens.push_back(screen_id);
+      }
+    }
+
+    return (tokens.size() > 1) ? tokens[1] : (tokens.size() > 0) ? get_icon_name(tokens[0], '_') : "";
+  }
+
   uint8_t EHMTX::find_icon(std::string name)
   {
     for (uint8_t i = 0; i < this->icon_count; i++)
@@ -331,6 +366,7 @@ namespace esphome
     register_service(&EHMTX::icon_screen, "icon_screen", {"icon_name", "text", "lifetime", "screen_time", "default_font", "r", "g", "b"});
     register_service(&EHMTX::alert_screen, "alert_screen", {"icon_name","text", "screen_time", "default_font", "r", "g", "b"});
     register_service(&EHMTX::icon_clock, "icon_clock", {"icon_name", "lifetime", "screen_time", "default_font", "r", "g", "b"});
+    register_service(&EHMTX::icon_date, "icon_date", {"icon_name", "lifetime", "screen_time", "default_font", "r", "g", "b"});
     #ifdef USE_GRAPH
       register_service(&EHMTX::graph_screen, "graph_screen", {"lifetime", "screen_time"});
     #endif
@@ -359,6 +395,9 @@ namespace esphome
     #ifdef USE_Fireplugin
       register_service(&EHMTX::fire_screen, "fire_screen", {"lifetime", "screen_time"});
     #endif
+
+    register_service(&EHMTX::icon_screen_progress, "icon_screen_progress", {"icon_name", "text", "progress", "lifetime", "screen_time", "default_font", "r", "g", "b"});
+
     ESP_LOGD(TAG, "Setup and running!");
   }
 
@@ -427,20 +466,21 @@ namespace esphome
       if (this->queue[i]->mode == mode)
       {
         bool force = true;
-        if ((mode == MODE_ICON_SCREEN) || (mode == MODE_ICON_CLOCK) ||(mode == MODE_FULL_SCREEN) || (mode == MODE_RAINBOW_ICON))
+        if ((mode == MODE_ICON_SCREEN) || (mode == MODE_ICON_CLOCK) || (mode == MODE_ICON_DATE) || (mode == MODE_FULL_SCREEN) || (mode == MODE_RAINBOW_ICON) || (mode == MODE_ICON_PROGRESS))
         {
           if (strcmp(this->queue[i]->icon_name.c_str(), icon_name.c_str()) != 0)
           {
             force = false;
           }
-          if (force)
-          {
-            ESP_LOGD(TAG, "force_screen: found position: %d", i);
-            this->queue[i]->last_time = 0;
-            this->queue[i]->endtime += this->queue[i]->screen_time_;
-            this->next_action_time = this->clock->now().timestamp;
-            ESP_LOGW(TAG, "force_screen: icon %s in mode %d", icon_name.c_str(), mode);
-          }
+        }
+        // Will allow force any screen [andrewjswan].
+        if (force)
+        {
+          ESP_LOGD(TAG, "force_screen: found position: %d", i);
+          this->queue[i]->last_time = 0;
+          this->queue[i]->endtime += this->queue[i]->screen_time_;
+          this->next_action_time = this->clock->now().timestamp;
+          ESP_LOGW(TAG, "force_screen: icon %s in mode %d", icon_name.c_str(), mode);
         }
       }
     }
@@ -531,6 +571,8 @@ namespace esphome
               case MODE_ICON_SCREEN:
               case MODE_RAINBOW_ICON:
               case MODE_ICON_CLOCK:
+              case MODE_ICON_DATE:
+              case MODE_ICON_PROGRESS:
                 infotext = this->queue[i]->icon_name.c_str();
                 break;
               case MODE_RAINBOW_TEXT:
@@ -613,6 +655,7 @@ namespace esphome
           {
             for (auto *t : on_next_screen_triggers_)
             {
+              ESP_LOGD(TAG, "on_next_screen trigger");
               t->process(this->queue[this->screen_pointer]->icon_name, this->queue[this->screen_pointer]->text);
             }
           }
@@ -641,9 +684,6 @@ namespace esphome
     }
     else
     {
-      // uint8_t w = (2 + (uint8_t)(32 / 16) * (this->boot_anim / 16)) % 32;
-      // this->display->clear();
-      // this->display->rectangle(0, 2, w, 4, this->rainbow_color); // Color(120, 190, 40));
       uint8_t w = 2 + ((uint8_t)(32 / 16) * (this->boot_anim/ 16)) % 32;
       uint8_t l = 32 / 2 - w / 2 ;
       this->display->rectangle(l, 2, w, 4, this->rainbow_color); 
@@ -721,7 +761,7 @@ namespace esphome
       {
         bool force = true;
         ESP_LOGD(TAG, "del_screen: icon %s in position: %s mode %d", icon_name.c_str(), this->queue[i]->icon_name.c_str(), mode);
-        if ((mode == MODE_ICON_SCREEN) || (mode == MODE_ICON_CLOCK) ||(mode == MODE_FULL_SCREEN) || (mode == MODE_RAINBOW_ICON))
+        if ((mode == MODE_ICON_SCREEN) || (mode == MODE_ICON_CLOCK) || (mode == MODE_ICON_DATE) || (mode == MODE_FULL_SCREEN) || (mode == MODE_RAINBOW_ICON) || (mode == MODE_ICON_PROGRESS))
         {
           if (this->string_has_ending(icon_name, "*"))
           {
@@ -753,7 +793,7 @@ namespace esphome
   }
 
   
-void EHMTX::alert_screen(std::string iconname, std::string text, int screen_time, bool default_font, int r, int g, int b)
+  void EHMTX::alert_screen(std::string iconname, std::string text, int screen_time, bool default_font, int r, int g, int b)
   {
     uint8_t icon = this->find_icon(iconname.c_str());
 
@@ -788,10 +828,12 @@ void EHMTX::alert_screen(std::string iconname, std::string text, int screen_time
     force_screen(iconname, MODE_ALERT_SCREEN);
   }
 
-
   void EHMTX::icon_screen(std::string iconname, std::string text, int lifetime, int screen_time, bool default_font, int r, int g, int b)
   {
-    uint8_t icon = this->find_icon(iconname.c_str());
+    std::string ic = get_icon_name(iconname);
+    std::string id = get_screen_id(iconname);
+
+    uint8_t icon = this->find_icon(ic.c_str());
 
     if (icon >= this->icon_count)
     {
@@ -799,17 +841,17 @@ void EHMTX::alert_screen(std::string iconname, std::string text, int screen_time
       icon = 0;
       for (auto *t : on_icon_error_triggers_)
       {
-        t->process(iconname);
+        t->process(ic);
       }
     }
-    EHMTX_queue *screen = this->find_icon_queue_element(icon);
+    EHMTX_queue *screen = this->find_mode_icon_queue_element(MODE_ICON_SCREEN, id);
 
     screen->text = text;
     screen->endtime = this->clock->now().timestamp + lifetime * 60;
     screen->text_color = Color(r, g, b);
     screen->default_font = default_font;
     screen->mode = MODE_ICON_SCREEN;
-    screen->icon_name = iconname;
+    screen->icon_name = id;
     screen->icon = icon;
     screen->calc_scroll_time(text, screen_time);
     for (auto *t : on_add_screen_triggers_)
@@ -820,9 +862,12 @@ void EHMTX::alert_screen(std::string iconname, std::string text, int screen_time
     screen->status();
   }
 
-  void EHMTX::icon_clock(std::string iconname, int lifetime, int screen_time, bool default_font, int r, int g, int b)
+  void EHMTX::icon_screen_progress(std::string iconname, std::string text, int progress, int lifetime, int screen_time, bool default_font, int r, int g, int b)
   {
-    uint8_t icon = this->find_icon(iconname.c_str());
+    std::string ic = get_icon_name(iconname);
+    std::string id = get_screen_id(iconname);
+
+    uint8_t icon = this->find_icon(ic.c_str());
 
     if (icon >= this->icon_count)
     {
@@ -830,18 +875,53 @@ void EHMTX::alert_screen(std::string iconname, std::string text, int screen_time
       icon = 0;
       for (auto *t : on_icon_error_triggers_)
       {
-        t->process(iconname);
+        t->process(ic);
       }
     }
-    EHMTX_queue *screen = this->find_mode_queue_element(MODE_ICON_CLOCK);
+    EHMTX_queue *screen = this->find_mode_icon_queue_element(MODE_ICON_PROGRESS, id);
+
+    screen->text = text;
+    screen->endtime = this->clock->now().timestamp + lifetime * 60;
+    screen->text_color = Color(r, g, b);
+    screen->default_font = default_font;
+    screen->mode = MODE_ICON_PROGRESS;
+    screen->icon_name = id;
+    screen->icon = icon;
+    screen->progress = (progress > 100) ? 100 : progress;
+    screen->calc_scroll_time(text, screen_time);
+    for (auto *t : on_add_screen_triggers_)
+    {
+      t->process(screen->icon_name, (uint8_t)screen->mode);
+    }
+    ESP_LOGD(TAG, "icon progress screen icon: %d iconname: %s text: %s progress %d lifetime: %d screen_time: %d", icon, iconname.c_str(), text.c_str(), progress, lifetime, screen_time);
+    screen->status();
+  }
+
+  void EHMTX::icon_clock(std::string iconname, int lifetime, int screen_time, bool default_font, int r, int g, int b)
+  {
+    std::string ic = get_icon_name(iconname);
+    std::string id = get_screen_id(iconname);
+
+    uint8_t icon = this->find_icon(ic.c_str());
+
+    if (icon >= this->icon_count)
+    {
+      ESP_LOGW(TAG, "icon %d not found => default: 0", icon);
+      icon = 0;
+      for (auto *t : on_icon_error_triggers_)
+      {
+        t->process(ic);
+      }
+    }
+    EHMTX_queue *screen = this->find_mode_icon_queue_element(MODE_ICON_CLOCK, id);
 
     screen->endtime = this->clock->now().timestamp + lifetime * 60;
     screen->text_color = Color(r, g, b);
     screen->default_font = default_font;
     screen->mode = MODE_ICON_CLOCK;
-    screen->icon_name = iconname;
+    screen->icon_name = id;
     screen->icon = icon;
-    screen->screen_time_ =  screen_time;
+    screen->screen_time_ = screen_time;
     for (auto *t : on_add_screen_triggers_)
     {
       t->process(screen->icon_name, (uint8_t)screen->mode);
@@ -850,9 +930,12 @@ void EHMTX::alert_screen(std::string iconname, std::string text, int screen_time
     screen->status();
   }
 
-  void EHMTX::rainbow_icon_screen(std::string iconname, std::string text, int lifetime, int screen_time, bool default_font)
+  void EHMTX::icon_date(std::string iconname, int lifetime, int screen_time, bool default_font, int r, int g, int b)
   {
-    uint8_t icon = this->find_icon(iconname.c_str());
+    std::string ic = get_icon_name(iconname);
+    std::string id = get_screen_id(iconname);
+
+    uint8_t icon = this->find_icon(ic.c_str());
 
     if (icon >= this->icon_count)
     {
@@ -860,17 +943,50 @@ void EHMTX::alert_screen(std::string iconname, std::string text, int screen_time
       icon = 0;
       for (auto *t : on_icon_error_triggers_)
       {
-        t->process(iconname);
+        t->process(ic);
       }
     }
-    EHMTX_queue *screen = this->find_icon_queue_element(icon);
+    EHMTX_queue *screen = this->find_mode_icon_queue_element(MODE_ICON_DATE, id);
+
+    screen->endtime = this->clock->now().timestamp + lifetime * 60;
+    screen->text_color = Color(r, g, b);
+    screen->default_font = default_font;
+    screen->mode = MODE_ICON_DATE;
+    screen->icon_name = id;
+    screen->icon = icon;
+    screen->screen_time_ = screen_time;
+    for (auto *t : on_add_screen_triggers_)
+    {
+      t->process(screen->icon_name, (uint8_t)screen->mode);
+    }
+    ESP_LOGD(TAG, "icon date icon: %d iconname: %s lifetime: %d screen_time: %d", icon, iconname.c_str(), lifetime, screen_time);
+    screen->status();
+  }
+
+  void EHMTX::rainbow_icon_screen(std::string iconname, std::string text, int lifetime, int screen_time, bool default_font)
+  {
+    std::string ic = get_icon_name(iconname);
+    std::string id = get_screen_id(iconname);
+
+    uint8_t icon = this->find_icon(ic.c_str());
+
+    if (icon >= this->icon_count)
+    {
+      ESP_LOGW(TAG, "icon %d not found => default: 0", icon);
+      icon = 0;
+      for (auto *t : on_icon_error_triggers_)
+      {
+        t->process(ic);
+      }
+    }
+    EHMTX_queue *screen = this->find_mode_icon_queue_element(MODE_RAINBOW_ICON, id);
 
     screen->text = text;
 
     screen->endtime = this->clock->now().timestamp + lifetime * 60;
     screen->default_font = default_font;
     screen->mode = MODE_RAINBOW_ICON;
-    screen->icon_name = iconname;
+    screen->icon_name = id;
     screen->icon = icon;
     screen->calc_scroll_time(text, screen_time);
     for (auto *t : on_add_screen_triggers_)
@@ -939,7 +1055,6 @@ void EHMTX::alert_screen(std::string iconname, std::string text, int screen_time
     screen->status();
   }
 
-
   void EHMTX::text_screen(std::string text, int lifetime, int screen_time, bool default_font, int r, int g, int b)
   {
     EHMTX_queue *screen = this->find_free_queue_element();
@@ -964,7 +1079,7 @@ void EHMTX::alert_screen(std::string iconname, std::string text, int screen_time
     screen->status();
   }
 
-void EHMTX::fire_screen( int lifetime, int screen_time)
+  void EHMTX::fire_screen(int lifetime, int screen_time)
   {
     EHMTX_queue *screen = this->find_mode_queue_element(MODE_FIRE);
     screen->mode = MODE_FIRE;
@@ -1038,9 +1153,12 @@ void EHMTX::fire_screen( int lifetime, int screen_time)
   {
     for (size_t i = 0; i < MAXQUEUE; i++)
     {
-      if ((this->queue[i]->mode == MODE_ICON_SCREEN) && (this->queue[i]->icon == icon))
+      if ( ((this->queue[i]->mode == MODE_ICON_SCREEN) ||
+            (this->queue[i]->mode == MODE_RAINBOW_ICON) ||
+            (this->queue[i]->mode == MODE_ICON_PROGRESS)) &&
+          (this->queue[i]->icon == icon) )
       {
-        ESP_LOGD(TAG, "free_screen: found by icon");
+        ESP_LOGD(TAG, "icon_screen: found by icon");
         return this->queue[i];
       }
     }
@@ -1063,7 +1181,6 @@ void EHMTX::fire_screen( int lifetime, int screen_time)
 
   EHMTX_queue *EHMTX::find_mode_queue_element(uint8_t mode)
   {
-    time_t ts = this->clock->now().timestamp;
     for (size_t i = 0; i < MAXQUEUE; i++)
     {
       if (this->queue[i]->mode == mode)
@@ -1075,6 +1192,18 @@ void EHMTX::fire_screen( int lifetime, int screen_time)
     return this->find_free_queue_element();
   }
 
+  EHMTX_queue *EHMTX::find_mode_icon_queue_element(uint8_t mode, std::string name)
+  {
+    for (size_t i = 0; i < MAXQUEUE; i++)
+    {
+      if (this->queue[i]->mode == mode && strcmp(this->queue[i]->icon_name.c_str(), name.c_str()) == 0)
+      {
+        ESP_LOGD(TAG, "find screen: found by mode %d icon %s", i, name);
+        return this->queue[i];
+      }
+    }
+    return this->find_free_queue_element();
+  }
 
   void EHMTX::set_show_seconds(bool b)
   {
@@ -1137,7 +1266,7 @@ void EHMTX::fire_screen( int lifetime, int screen_time)
     ESP_LOGD(TAG, "set_graph");
   }
 
-void EHMTX::graph_screen(int lifetime, int screen_time)
+  void EHMTX::graph_screen(int lifetime, int screen_time)
   {
     ESP_LOGD(TAG, "graph screen: lifetime: %d screen_time: %d", lifetime, screen_time);
     
@@ -1195,7 +1324,7 @@ void EHMTX::graph_screen(int lifetime, int screen_time)
         }
       }
     }
-  };
+  }
 
   void EHMTX::dump_config()
   {

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -894,7 +894,7 @@ namespace esphome
     screen->mode = MODE_ICON_PROGRESS;
     screen->icon_name = id;
     screen->icon = icon;
-    screen->progress = (progress > 100) ? 100 : progress;
+    screen->progress = (progress > 100) ? 100 : (progress < -100) ? -100 : progress;
     screen->calc_scroll_time(text, screen_time);
     for (auto *t : on_add_screen_triggers_)
     {

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -1424,18 +1424,25 @@ namespace esphome
       if (this->screen_pointer != MAXQUEUE) {
         this->queue[this->screen_pointer]->draw();  
       }
-      if (this->queue[this->screen_pointer]->mode != MODE_FULL_SCREEN && this->queue[this->screen_pointer]->mode != MODE_BITMAP_SCREEN)
+      if (this->queue[this->screen_pointer]->mode != MODE_FULL_SCREEN &&
+          this->queue[this->screen_pointer]->mode != MODE_BITMAP_SCREEN &&
+          this->queue[this->screen_pointer]->mode != MODE_ICON_PROGRESS)
       {
         this->draw_gauge();
       }
 #ifndef EHMTXv2_ALWAYS_SHOW_RLINDICATORS
-      if (this->queue[this->screen_pointer]->mode != MODE_CLOCK && this->queue[this->screen_pointer]->mode != MODE_DATE && this->queue[this->screen_pointer]->mode != MODE_FULL_SCREEN && this->queue[this->screen_pointer]->mode != MODE_BITMAP_SCREEN)
+      if (this->queue[this->screen_pointer]->mode != MODE_CLOCK &&
+          this->queue[this->screen_pointer]->mode != MODE_DATE &&
+          this->queue[this->screen_pointer]->mode != MODE_FULL_SCREEN &&
+          this->queue[this->screen_pointer]->mode != MODE_BITMAP_SCREEN)
       {
 #endif
 
         this->draw_rindicator();
 #ifndef EHMTXv2_ALWAYS_SHOW_RLINDICATORS
-        if (this->queue[this->screen_pointer]->mode != MODE_ICON_SCREEN && this->queue[this->screen_pointer]->mode != MODE_RAINBOW_ICON && !this->display_gauge)
+        if (this->queue[this->screen_pointer]->mode != MODE_ICON_SCREEN &&
+            this->queue[this->screen_pointer]->mode != MODE_RAINBOW_ICON &&
+            !this->display_gauge)
         {
 #endif
           this->draw_lindicator();

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -201,17 +201,17 @@ namespace esphome
     return MAXICONS;
   }
 
-  uint8_t EHMTX::find_icon_in_queue(std::string name)
+  uint8_t EHMTX::find_screen_in_queue(std::string name)
   {
     for (uint8_t i = 0; i < MAXQUEUE; i++)
     {
-      if (strcmp(this->queue[i]->icon_name.c_str(), name.c_str()) == 0)
+      if (strcmp(this->queue[i]->screen_id.c_str(), name.c_str()) == 0)
       {
-        ESP_LOGD(TAG, "find icon in queue: icon: %s at position %d", name.c_str(), i);
+        ESP_LOGD(TAG, "find screen in queue: screen: %s at position %d", name.c_str(), i);
         return i;
       }
     }
-    ESP_LOGW(TAG, "find icon in queue: icon: %s not found", name.c_str());
+    ESP_LOGW(TAG, "find screen in queue: screen: %s not found", name.c_str());
     return MAXICONS;
   }
 
@@ -324,8 +324,8 @@ namespace esphome
     register_service(&EHMTX::set_clock_color, "set_clock_color", {"r", "g", "b"});
     register_service(&EHMTX::set_text_color, "set_text_color", {"r", "g", "b"});
 
-    register_service(&EHMTX::del_screen, "del_screen", {"icon_name", "mode"});
-    register_service(&EHMTX::force_screen, "force_screen", {"icon_name", "mode"});
+    register_service(&EHMTX::del_screen, "del_screen", {"screen_id", "mode"});
+    register_service(&EHMTX::force_screen, "force_screen", {"screen_id", "mode"});
 
     register_service(&EHMTX::full_screen, "full_screen", {"icon_name", "lifetime", "screen_time"});
     register_service(&EHMTX::icon_screen, "icon_screen", {"icon_name", "text", "lifetime", "screen_time", "default_font", "r", "g", "b"});
@@ -420,7 +420,7 @@ namespace esphome
     }
   }
 
-  void EHMTX::force_screen(std::string icon_name, int mode)
+  void EHMTX::force_screen(std::string screen_id, int mode)
   {
     for (uint8_t i = 0; i < MAXQUEUE; i++)
     {
@@ -429,7 +429,7 @@ namespace esphome
         bool force = true;
         if ((mode == MODE_ICON_SCREEN) || (mode == MODE_ICON_CLOCK) ||(mode == MODE_FULL_SCREEN) || (mode == MODE_RAINBOW_ICON))
         {
-          if (strcmp(this->queue[i]->icon_name.c_str(), icon_name.c_str()) != 0)
+          if (strcmp(this->queue[i]->screen_id.c_str(), screen_id.c_str()) != 0)
           {
             force = false;
           }
@@ -439,7 +439,7 @@ namespace esphome
             this->queue[i]->last_time = 0;
             this->queue[i]->endtime += this->queue[i]->screen_time_;
             this->next_action_time = this->clock->now().timestamp;
-            ESP_LOGW(TAG, "force_screen: icon %s in mode %d", icon_name.c_str(), mode);
+            ESP_LOGW(TAG, "force_screen: icon %s in mode %d", screen_id.c_str(), mode);
           }
         }
       }
@@ -505,7 +505,7 @@ namespace esphome
           this->queue[i]->endtime = 0;
           if (this->queue[i]->mode != MODE_EMPTY)
           {
-            ESP_LOGD(TAG, "remove expired queue element: slot %d: mode: %d icon_name: %s text: %s", i, this->queue[i]->mode, this->queue[i]->icon_name.c_str(), this->queue[i]->text.c_str());
+            ESP_LOGD(TAG, "remove expired queue element: slot %d: mode: %d screen_id: %s text: %s", i, this->queue[i]->mode, this->queue[i]->screen_id.c_str(), this->queue[i]->text.c_str());
             for (auto *t : on_expired_screen_triggers_)
             {
               infotext = "";
@@ -526,12 +526,12 @@ namespace esphome
                 infotext = "clock";
                 break;
               case MODE_FULL_SCREEN:
-                infotext = "full screen " + this->queue[i]->icon_name;
+                infotext = "full screen " + this->queue[i]->screen_id;
                 break;
               case MODE_ICON_SCREEN:
               case MODE_RAINBOW_ICON:
               case MODE_ICON_CLOCK:
-                infotext = this->queue[i]->icon_name.c_str();
+                infotext = this->queue[i]->screen_id.c_str();
                 break;
               case MODE_RAINBOW_TEXT:
               case MODE_TEXT_SCREEN:
@@ -546,7 +546,7 @@ namespace esphome
               default:
                 break;
               }
-              t->process(this->queue[i]->icon_name, infotext);
+              t->process(this->queue[i]->screen_id, infotext);
             }
           }
           this->queue[i]->mode = MODE_EMPTY;
@@ -613,7 +613,7 @@ namespace esphome
           {
             for (auto *t : on_next_screen_triggers_)
             {
-              t->process(this->queue[this->screen_pointer]->icon_name, this->queue[this->screen_pointer]->text);
+              t->process(this->queue[this->screen_pointer]->screen_id, this->queue[this->screen_pointer]->text);
             }
           }
         }
@@ -713,26 +713,26 @@ namespace esphome
     this->special_font = font;
   }
 
-  void EHMTX::del_screen(std::string icon_name, int mode)
+  void EHMTX::del_screen(std::string screen_id, int mode)
   {
     for (uint8_t i = 0; i < MAXQUEUE; i++)
     {
       if (this->queue[i]->mode == mode)
       {
         bool force = true;
-        ESP_LOGD(TAG, "del_screen: icon %s in position: %s mode %d", icon_name.c_str(), this->queue[i]->icon_name.c_str(), mode);
+        ESP_LOGD(TAG, "del_screen: screen %s in position: %s mode %d", screen_id.c_str(), this->queue[i]->screen_id.c_str(), mode);
         if ((mode == MODE_ICON_SCREEN) || (mode == MODE_ICON_CLOCK) ||(mode == MODE_FULL_SCREEN) || (mode == MODE_RAINBOW_ICON))
         {
-          if (this->string_has_ending(icon_name, "*"))
+          if (this->string_has_ending(screen_id, "*"))
           {
-            std::string comparename = icon_name.substr(0, icon_name.length() - 1);
+            std::string comparename = screen_id.substr(0, screen_id.length() - 1);
 
-            if (this->queue[i]->icon_name.rfind(comparename, 0) != 0)
+            if (this->queue[i]->screen_id.rfind(comparename, 0) != 0)
             {
               force = false;
             }
           }
-          else if (strcmp(this->queue[i]->icon_name.c_str(), icon_name.c_str()) != 0)
+          else if (strcmp(this->queue[i]->screen_id.c_str(), screen_id.c_str()) != 0)
           {
             force = false;
           }
@@ -773,14 +773,14 @@ void EHMTX::alert_screen(std::string iconname, std::string text, int screen_time
     screen->text_color = Color(r, g, b);
     screen->default_font = default_font;
     screen->mode = MODE_ALERT_SCREEN;
-    screen->icon_name = iconname;
+    screen->screen_id = iconname;
     screen->icon = icon;
     screen->calc_scroll_time(text, screen_time);
     // time needed for scrolling
     screen->endtime = this->clock->now().timestamp + screen->screen_time_ + 1;
     for (auto *t : on_add_screen_triggers_)
     {
-      t->process(screen->icon_name, (uint8_t)screen->mode);
+      t->process(screen->screen_id, (uint8_t)screen->mode);
     }
     ESP_LOGD(TAG, "alert screen icon: %d iconname: %s text: %s screen_time: %d", icon, iconname.c_str(), text.c_str(), screen_time);
     screen->status();
@@ -809,12 +809,12 @@ void EHMTX::alert_screen(std::string iconname, std::string text, int screen_time
     screen->text_color = Color(r, g, b);
     screen->default_font = default_font;
     screen->mode = MODE_ICON_SCREEN;
-    screen->icon_name = iconname;
+    screen->screen_id = iconname;
     screen->icon = icon;
     screen->calc_scroll_time(text, screen_time);
     for (auto *t : on_add_screen_triggers_)
     {
-      t->process(screen->icon_name, (uint8_t)screen->mode);
+      t->process(screen->screen_id, (uint8_t)screen->mode);
     }
     ESP_LOGD(TAG, "icon screen icon: %d iconname: %s text: %s lifetime: %d screen_time: %d", icon, iconname.c_str(), text.c_str(), lifetime, screen_time);
     screen->status();
@@ -839,12 +839,12 @@ void EHMTX::alert_screen(std::string iconname, std::string text, int screen_time
     screen->text_color = Color(r, g, b);
     screen->default_font = default_font;
     screen->mode = MODE_ICON_CLOCK;
-    screen->icon_name = iconname;
+    screen->screen_id = iconname;
     screen->icon = icon;
     screen->screen_time_ =  screen_time;
     for (auto *t : on_add_screen_triggers_)
     {
-      t->process(screen->icon_name, (uint8_t)screen->mode);
+      t->process(screen->screen_id, (uint8_t)screen->mode);
     }
     ESP_LOGD(TAG, "icon clock icon: %d iconname: %s lifetime: %d screen_time: %d", icon, iconname.c_str(), lifetime, screen_time);
     screen->status();
@@ -870,12 +870,12 @@ void EHMTX::alert_screen(std::string iconname, std::string text, int screen_time
     screen->endtime = this->clock->now().timestamp + lifetime * 60;
     screen->default_font = default_font;
     screen->mode = MODE_RAINBOW_ICON;
-    screen->icon_name = iconname;
+    screen->screen_id = iconname;
     screen->icon = icon;
     screen->calc_scroll_time(text, screen_time);
     for (auto *t : on_add_screen_triggers_)
     {
-      t->process(screen->icon_name, (uint8_t)screen->mode);
+      t->process(screen->screen_id, (uint8_t)screen->mode);
     }
     ESP_LOGD(TAG, "rainbow icon screen icon: %d iconname: %s text: %s lifetime: %d screen_time: %d", icon, iconname.c_str(), text.c_str(), lifetime, screen_time);
     screen->status();
@@ -996,12 +996,12 @@ void EHMTX::fire_screen( int lifetime, int screen_time)
 
     screen->mode = MODE_FULL_SCREEN;
     screen->icon = icon;
-    screen->icon_name = iconname;
+    screen->screen_id = iconname;
     screen->screen_time_ = screen_time;
     screen->endtime = this->clock->now().timestamp + lifetime * 60;
     for (auto *t : on_add_screen_triggers_)
     {
-      t->process(screen->icon_name, (uint8_t)screen->mode);
+      t->process(screen->screen_id, (uint8_t)screen->mode);
     }
     ESP_LOGD(TAG, "full screen: icon: %d iconname: %s lifetime: %d screen_time:%d ", icon, iconname.c_str(), lifetime, screen_time);
     screen->status();

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -521,7 +521,7 @@ namespace esphome
       time_t ts = this->clock->now().timestamp;
       for (size_t i = 0; i < MAXQUEUE; i++)
       {
-        if ((this->queue[i]->mode == MODE_CLOCK) || (this->queue[i]->mode == MODE_RAINBOW_CLOCK))
+        if ((this->queue[i]->mode == MODE_CLOCK) || (this->queue[i]->mode == MODE_RAINBOW_CLOCK) || (this->queue[i]->mode == MODE_ICON_CLOCK))
         {
           if (ts > (this->queue[i]->last_time + EHMTXv2_CLOCK_INTERVALL))
           {

--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -135,7 +135,7 @@ namespace esphome
 
     void remove_expired_queue_element();
     uint8_t find_oldest_queue_element();
-    uint8_t find_icon_in_queue(std::string);
+    uint8_t find_screen_in_queue(std::string);
     void force_screen(std::string name, int mode = MODE_ICON_SCREEN);
     void add_icon(EHMTX_Icon *icon);
     bool show_display = false;
@@ -188,7 +188,7 @@ namespace esphome
     void bitmap_screen(std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME);
     void color_gauge(std::string text);
     void bitmap_small(std::string, std::string,int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
-    void rainbow_icon_screen(std::string icon_name, std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true);
+    void rainbow_icon_screen(std::string icon, std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true);
     void rainbow_text_screen(std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true);
     void rainbow_clock_screen(int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true);
     void rainbow_date_screen(int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true);
@@ -228,11 +228,11 @@ namespace esphome
 
 #ifdef USE_ESP32
     PROGMEM std::string text;
-    PROGMEM std::string icon_name;
+    PROGMEM std::string screen_id;
 #endif
 #ifdef USE_ESP8266
     std::string text;
-    std::string icon_name;
+    std::string screen_id;
 #endif
 
     EHMTX_queue(EHMTX *config);

--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -135,7 +135,7 @@ namespace esphome
 
     void remove_expired_queue_element();
     uint8_t find_oldest_queue_element();
-    uint8_t find_screen_in_queue(std::string);
+    uint8_t find_icon_in_queue(std::string);
     void force_screen(std::string name, int mode = MODE_ICON_SCREEN);
     void add_icon(EHMTX_Icon *icon);
     bool show_display = false;
@@ -188,7 +188,7 @@ namespace esphome
     void bitmap_screen(std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME);
     void color_gauge(std::string text);
     void bitmap_small(std::string, std::string,int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
-    void rainbow_icon_screen(std::string icon, std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true);
+    void rainbow_icon_screen(std::string icon_name, std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true);
     void rainbow_text_screen(std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true);
     void rainbow_clock_screen(int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true);
     void rainbow_date_screen(int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true);
@@ -228,11 +228,11 @@ namespace esphome
 
 #ifdef USE_ESP32
     PROGMEM std::string text;
-    PROGMEM std::string screen_id;
+    PROGMEM std::string icon_name;
 #endif
 #ifdef USE_ESP8266
     std::string text;
-    std::string screen_id;
+    std::string icon_name;
 #endif
 
     EHMTX_queue(EHMTX *config);

--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -177,7 +177,7 @@ namespace esphome
     void hide_alarm();
     void full_screen(std::string icon, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME);
     void icon_screen(std::string icon, std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
-    void alert_screen(std::string iconname, std::string text, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = CA_RED, int g = CA_GREEN, int b = CA_BLUE);
+    void alert_screen(std::string icon, std::string text, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = CA_RED, int g = CA_GREEN, int b = CA_BLUE);
     void icon_clock(std::string icon, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
     void text_screen(std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
     void clock_screen(int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);

--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -24,7 +24,7 @@ const uint8_t TEXTSCROLLSTART = 8;
 const uint8_t TEXTSTARTOFFSET = (32 - 8);
 
 const uint16_t POLLINGINTERVAL = 250;
-static const char *const EHMTX_VERSION = "2023.9.0";
+static const char *const EHMTX_VERSION = "2023.9.1";
 static const char *const TAG = "EHMTXv2";
 
 enum show_mode : uint8_t
@@ -46,7 +46,9 @@ enum show_mode : uint8_t
   MODE_FIRE = 14,
   MODE_ICON_CLOCK = 15,
   MODE_ALERT_SCREEN = 16,
-  MODE_GRAPH_SCREEN = 17
+  MODE_GRAPH_SCREEN = 17,
+  MODE_ICON_DATE = 18,
+  MODE_ICON_PROGRESS = 19
 };
 
 namespace esphome
@@ -79,6 +81,7 @@ namespace esphome
     std::vector<EHMTXAddScreenTrigger *> on_add_screen_triggers_;
     EHMTX_queue *find_icon_queue_element(uint8_t icon);
     EHMTX_queue *find_mode_queue_element(uint8_t mode);
+    EHMTX_queue *find_mode_icon_queue_element(uint8_t mode, std::string name);
     EHMTX_queue *find_free_queue_element();
 
   public:
@@ -179,11 +182,13 @@ namespace esphome
     void icon_screen(std::string icon, std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
     void alert_screen(std::string icon, std::string text, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = CA_RED, int g = CA_GREEN, int b = CA_BLUE);
     void icon_clock(std::string icon, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
+    void icon_date(std::string icon, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
     void text_screen(std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
     void clock_screen(int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
     void date_screen(int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
     void blank_screen(int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME);
     void color_screen(int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
+    void icon_screen_progress(std::string icon, std::string text, int progress, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
 
     void bitmap_screen(std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME);
     void color_gauge(std::string text);
@@ -225,6 +230,7 @@ namespace esphome
     uint16_t scroll_reset;
     Color text_color;
     show_mode mode;
+    int8_t progress;
 
 #ifdef USE_ESP32
     PROGMEM std::string text;

--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -94,7 +94,7 @@ namespace esphome
     uint16_t hue_ = 0;
     void dump_config();
 #ifdef USE_ESP32
-    PROGMEM Color text_color, alarm_color, rindicator_color,  lindicator_color, today_color, weekday_color, rainbow_color, clock_color;
+    PROGMEM Color text_color, alarm_color, rindicator_color, lindicator_color, today_color, weekday_color, rainbow_color, clock_color, info_lcolor, info_rcolor;
     PROGMEM Color bitmap[256];
     PROGMEM Color sbitmap[64];
     PROGMEM Color cgauge[8];
@@ -102,7 +102,7 @@ namespace esphome
 #endif
 
 #ifdef USE_ESP8266
-    Color text_color, alarm_color, gauge_color, gauge_bgcolor,rindicator_color,lindicator_color, today_color, weekday_color, rainbow_color, clock_color;
+    Color text_color, alarm_color, gauge_color, gauge_bgcolor,rindicator_color,lindicator_color, today_color, weekday_color, rainbow_color, clock_color, info_lcolor, info_rcolor;
     EHMTX_Icon *icons[MAXICONS];
     uint8_t gauge_value;
 #endif
@@ -172,6 +172,8 @@ namespace esphome
     void set_today_color(int r = C_RED, int g = C_GREEN, int b = C_BLUE);
     void set_weekday_color(int r = CD_RED, int g = CD_GREEN, int b = CD_BLUE);
     void set_clock_color(int r = C_RED, int g = C_GREEN, int b = C_BLUE);
+    void set_infotext_color(int lr = CG_GREY, int lg = CG_GREY, int lb = CG_GREY, int rr = CG_GREY, int rg = CG_GREY, int rb = CG_GREY);
+
     void show_alarm(int r = CA_RED, int g = CA_GREEN, int b = CA_BLUE, int s = 2);
     void show_gauge(int v, int r = C_RED, int g = C_GREEN, int b = C_BLUE,int bgr = CG_GREY, int bgg = CG_GREY, int bgb = CG_GREY); // int because of register_service
     void hide_gauge();

--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -248,9 +248,11 @@ namespace esphome
       {
       case MODE_BLANK:
         break;
+
       case MODE_COLOR:
         this->config_->display->fill(this->text_color);
         break;
+
       case MODE_BITMAP_SCREEN:
 #ifndef USE_ESP8266
         for (uint8_t x = 0; x < 32; x++)
@@ -262,11 +264,13 @@ namespace esphome
         }
 #endif
         break;
+
 #ifdef USE_GRAPH
       case MODE_GRAPH_SCREEN:
         this->config_->display->graph(0,0, this->config_->graph);
         break;
 #endif
+
       case MODE_BITMAP_SMALL:
 #ifndef USE_ESP8266
         color_ = this->text_color;
@@ -324,6 +328,7 @@ namespace esphome
           this->config_->display->print(15 + xoffset, yoffset, font, this->config_->alarm_color, display::TextAlign::BASELINE_CENTER, "!t!");
         }
         break;
+
       case MODE_RAINBOW_DATE:
       case MODE_DATE:
         if (this->config_->clock->now().is_valid())
@@ -346,45 +351,27 @@ namespace esphome
           this->config_->display->print(xoffset + 15, yoffset, font, this->config_->alarm_color, display::TextAlign::BASELINE_CENTER, "!d!");
         }
         break;
+
       case MODE_FULL_SCREEN:
         this->config_->display->image(0, 0, this->config_->icons[this->icon]);
         break;
-      case MODE_ICON_CLOCK:
-        if (this->config_->clock->now().is_valid()) // valid time
-        {
-          color_ = this->text_color;
-          time_t ts = this->config_->clock->now().timestamp;
-          this->config_->display->strftime(xoffset + 19, yoffset, font, color_, display::TextAlign::BASELINE_CENTER, EHMTXv2_TIME_FORMAT,
-                                           this->config_->clock->now());
-          this->config_->display->image(0, 0, this->config_->icons[this->icon]);
-          this->config_->draw_day_of_week(true);
 
-          // TODO: Add a color to display text on the icon 
-          if (this->icon_name == "day")
-          {
-            this->config_->display->printf(0, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%d", this->config_->clock->now().day_of_month / 10 % 10);
-            this->config_->display->printf(5, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%d", this->config_->clock->now().day_of_month % 10);
-          }
-          if (this->icon_name == "weekday")
-          {
-            // TODO: Added for testing for now, will need to rethink it [andrewjswan]
-            std::string day[]={"SU","MO","TU","WE","TH","FR","SA"};
-            this->config_->display->printf(0, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%s", day[this->config_->clock->now().day_of_week - 1][0]);
-            this->config_->display->printf(5, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%s", day[this->config_->clock->now().day_of_week - 1][1]);
-          }
-        }
-        else
-        {
-          this->config_->display->print( xoffset + 19, yoffset, font, this->config_->alarm_color, display::TextAlign::BASELINE_CENTER, "!t!");
-        }
-        break;
+      case MODE_ICON_CLOCK:
       case MODE_ICON_DATE:
         if (this->config_->clock->now().is_valid()) // valid time
         {
           color_ = this->text_color;
           time_t ts = this->config_->clock->now().timestamp;
-          this->config_->display->strftime(xoffset + 19, yoffset, font, color_, display::TextAlign::BASELINE_CENTER, EHMTXv2_DATE_FORMAT,
-                                           this->config_->clock->now());
+          if (this->mode == MODE_ICON_CLOCK)
+          {
+            this->config_->display->strftime(xoffset + 19, yoffset, font, color_, display::TextAlign::BASELINE_CENTER, EHMTXv2_TIME_FORMAT,
+                                             this->config_->clock->now());
+          }
+          else
+          {
+            this->config_->display->strftime(xoffset + 19, yoffset, font, color_, display::TextAlign::BASELINE_CENTER, EHMTXv2_DATE_FORMAT,
+                                             this->config_->clock->now());
+          }
           this->config_->display->image(0, 0, this->config_->icons[this->icon]);
           this->config_->draw_day_of_week(true);
 
@@ -407,6 +394,7 @@ namespace esphome
           this->config_->display->print( xoffset + 19, yoffset, font, this->config_->alarm_color, display::TextAlign::BASELINE_CENTER, "!t!");
         }
         break;
+
       case MODE_ICON_SCREEN:
       case MODE_ALERT_SCREEN:
       case MODE_RAINBOW_ICON:

--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -379,14 +379,14 @@ namespace esphome
           if (this->icon_name == "day")
           {
             this->config_->display->printf(0, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%d", this->config_->clock->now().day_of_month / 10 % 10);
-            this->config_->display->printf(5, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%d", this->config_->clock->now().day_of_month % 10);
+            this->config_->display->printf(7, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%d", this->config_->clock->now().day_of_month % 10);
           }
           if (this->icon_name == "weekday")
           {
             // TODO: Added for testing for now, will need to rethink it [andrewjswan]
             std::string day[]={"SU","MO","TU","WE","TH","FR","SA"};
             this->config_->display->printf(0, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%s", day[this->config_->clock->now().day_of_week - 1][0]);
-            this->config_->display->printf(5, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%s", day[this->config_->clock->now().day_of_week - 1][1]);
+            this->config_->display->printf(7, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%s", day[this->config_->clock->now().day_of_week - 1][1]);
           }
         }
         else
@@ -399,7 +399,6 @@ namespace esphome
       case MODE_ALERT_SCREEN:
       case MODE_RAINBOW_ICON:
       case MODE_ICON_PROGRESS:
-      {
         color_ = (this->mode == MODE_RAINBOW_ICON) ? this->config_->rainbow_color : this->text_color;
 #ifdef EHMTXv2_USE_RTL
         this->config_->display->print(this->xpos() + xoffset, yoffset, font, color_, esphome::display::TextAlign::BASELINE_RIGHT,
@@ -412,13 +411,11 @@ namespace esphome
         {
           if (this->progress >= 0)
           {
-            color_ = esphome::light::ESPHSVColor(this->progress * 120 / 100, 255, 255).to_rgb();
-            this->config_->display->line(10, 0, 10, 7, esphome::display::COLOR_OFF);
+            this->config_->display->line(8, 0, 8, 7, esphome::display::COLOR_OFF);
+            this->config_->display->image(0, 0, this->config_->icons[this->icon]);
+
+            color_ = esphome::light::ESPHSVColor(this->progress * 120 / 100, 240, 240).to_rgb();
             this->config_->display->line(9, 7, 9 + this->progress * 22 / 100, 7, color_);
-          }
-          else
-          {
-            this->config_->display->line(9, 7, 31, 7, esphome::display::COLOR_OFF);
           }
         }
         else
@@ -434,8 +431,8 @@ namespace esphome
             this->config_->display->image(0, 0, this->config_->icons[this->icon]);
           }
         }
-      }
-      break;
+        break;
+
       case MODE_TEXT_SCREEN:
       case MODE_RAINBOW_TEXT:
         color_ = (this->mode == MODE_RAINBOW_TEXT) ? this->config_->rainbow_color : this->text_color;
@@ -447,9 +444,9 @@ namespace esphome
                                       this->text.c_str());
 #endif
         break;
+
 #ifdef USE_Fireplugin
       case MODE_FIRE:
-      {
         int16_t x = 0;
         int16_t y = 0;
 
@@ -517,10 +514,9 @@ namespace esphome
             this->config_->display->draw_pixel_at(x, y, heatColor(m_heat[x + y * 32]));
           }
         }
-      }
-
-      break;
+        break;
 #endif
+
       default:
         ESP_LOGD(TAG, "no screen to draw!");
         this->config_->next_action_time = 0;

--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -414,13 +414,13 @@ namespace esphome
 #endif
         if (this->mode == MODE_ICON_PROGRESS)
         {
-          if (this->progress >= 0)
-          {
-            this->config_->display->line(8, 0, 8, 7, esphome::display::COLOR_OFF);
-            this->config_->display->image(0, 0, this->config_->icons[this->icon]);
+          this->config_->display->line(8, 0, 8, 7, esphome::display::COLOR_OFF);
+          this->config_->display->image(0, 0, this->config_->icons[this->icon]);
 
-            color_ = esphome::light::ESPHSVColor(this->progress * 120 / 100, 240, 240).to_rgb();
-            this->config_->display->line(9, 7, 9 + this->progress * 22 / 100, 7, color_);
+          if (this->progress != 0)
+          {
+            color_ = esphome::light::ESPHSVColor(this->progress * 120 / 100 + (this->progress < 0 ? 120 : 0), 240, 240).to_rgb();
+            this->config_->display->line(9, 7, 9 + abs(this->progress) * 22 / 100, 7, color_);
           }
         }
         else

--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -148,6 +148,7 @@ namespace esphome
       ESP_LOGD(TAG, "queue: small bitmap for: %d sec", this->screen_time_);
       break;
 #endif
+
     default:
       ESP_LOGD(TAG, "queue: UPPS");
       break;
@@ -378,15 +379,19 @@ namespace esphome
           // TODO: Add a color to display text on the icon 
           if (this->icon_name == "day")
           {
-            this->config_->display->printf(0, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%d", this->config_->clock->now().day_of_month / 10 % 10);
-            this->config_->display->printf(7, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%d", this->config_->clock->now().day_of_month % 10);
+            uint8_t d = this->config_->clock->now().day_of_month;
+
+            this->config_->display->printf(0, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%d", d / 10 % 10);
+            this->config_->display->printf(7, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%d", d % 10);
           }
           if (this->icon_name == "weekday")
           {
             // TODO: Added for testing for now, will need to rethink it [andrewjswan]
-            std::string day[]={"SU","MO","TU","WE","TH","FR","SA"};
-            this->config_->display->printf(0, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%s", day[this->config_->clock->now().day_of_week - 1][0]);
-            this->config_->display->printf(7, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%s", day[this->config_->clock->now().day_of_week - 1][1]);
+            std::string weekdays = "SUMOTUWETHFRSA"; // F("SUMOTUWETHFRSA")
+            uint8_t wd = this->config_->clock->now().day_of_week;
+
+            this->config_->display->printf(0, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%c", (weekdays[(wd - 1) * 2]));
+            this->config_->display->printf(7, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%c", (weekdays[(wd - 1) * 2 + 1]));
           }
         }
         else
@@ -447,6 +452,7 @@ namespace esphome
 
 #ifdef USE_Fireplugin
       case MODE_FIRE:
+      {
         int16_t x = 0;
         int16_t y = 0;
 
@@ -514,7 +520,8 @@ namespace esphome
             this->config_->display->draw_pixel_at(x, y, heatColor(m_heat[x + y * 32]));
           }
         }
-        break;
+      }
+      break;
 #endif
 
       default:

--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -74,7 +74,7 @@ namespace esphome
     this->last_time = 0;
     this->screen_time_ = 0;
     this->mode = MODE_EMPTY;
-    this->icon_name = "";
+    this->screen_id = "";
     this->icon = 0;
     this->text = "";
     this->default_font = true;
@@ -103,22 +103,22 @@ namespace esphome
       ESP_LOGD(TAG, "queue: graph for: %d sec", this->screen_time_);
       break;
     case MODE_FULL_SCREEN:
-      ESP_LOGD(TAG, "queue: full screen: \"%s\" for: %d sec", this->icon_name.c_str(), this->screen_time_);
+      ESP_LOGD(TAG, "queue: full screen: \"%s\" for: %d sec", this->screen_id.c_str(), this->screen_time_);
       break;
     case MODE_ICON_SCREEN:
-      ESP_LOGD(TAG, "queue: icon screen: \"%s\" text: %s for: %d sec", this->icon_name.c_str(), this->text.c_str(), this->screen_time_);
+      ESP_LOGD(TAG, "queue: icon screen: \"%s\" text: %s for: %d sec", this->screen_id.c_str(), this->text.c_str(), this->screen_time_);
       break;
     case MODE_ICON_CLOCK:
-      ESP_LOGD(TAG, "queue: icon \"%s\" for: %d sec", this->icon_name.c_str(), this->screen_time_);
+      ESP_LOGD(TAG, "queue: icon \"%s\" for: %d sec", this->screen_id.c_str(), this->screen_time_);
       break;
     case MODE_ALERT_SCREEN:
-      ESP_LOGD(TAG, "queue: icon \"%s\" for: %d sec", this->icon_name.c_str(), this->screen_time_);
+      ESP_LOGD(TAG, "queue: icon \"%s\" for: %d sec", this->screen_id.c_str(), this->screen_time_);
       break;
     case MODE_TEXT_SCREEN:
       ESP_LOGD(TAG, "queue: text text: \"%s\" for: %d sec", this->text.c_str(), this->screen_time_);
       break;
     case MODE_RAINBOW_ICON:
-      ESP_LOGD(TAG, "queue: rainbow icon: \"%s\" text: %s for: %d sec", this->icon_name.c_str(), this->text.c_str(), this->screen_time_);
+      ESP_LOGD(TAG, "queue: rainbow icon: \"%s\" text: %s for: %d sec", this->screen_id.c_str(), this->text.c_str(), this->screen_time_);
       break;
     case MODE_RAINBOW_TEXT:
       ESP_LOGD(TAG, "queue: rainbow text: \"%s\" for: %d sec", this->text.c_str(), this->screen_time_);

--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -376,22 +376,99 @@ namespace esphome
           this->config_->display->image(0, 0, this->config_->icons[this->icon]);
           this->config_->draw_day_of_week(true);
 
-          // TODO: Add a color to display text on the icon 
-          if (this->icon_name == "day")
+          if (this->icon_name.find("day") != std::string::npos || this->icon_name.find("weekday") != std::string::npos)
           {
-            uint8_t d = this->config_->clock->now().day_of_month;
+            int mode = 0;
+            std::size_t pos = icon_name.find("#");
+            if (pos != std::string::npos)
+            {
+              std::string str_mode = icon_name.substr(pos + 1);
+              if (str_mode.length())
+              {
+                mode = std::stoi(str_mode);
+              }
+            }
 
-            this->config_->display->printf(0, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%d", d / 10 % 10);
-            this->config_->display->printf(9, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%d", d % 10);
-          }
-          if (this->icon_name == "weekday")
-          {
-            // TODO: Added for testing for now, will need to rethink it [andrewjswan]
-            std::string weekdays = "SUMOTUWETHFRSA"; // F("SUMOTUWETHFRSA")
-            uint8_t wd = this->config_->clock->now().day_of_week;
+            // TODO: Add a color to display text on the icon 
+            if (this->icon_name.find("day") != std::string::npos)
+            {
+              uint8_t d = this->config_->clock->now().day_of_month;
 
-            this->config_->display->printf(0, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%c", (weekdays[(wd - 1) * 2]));
-            this->config_->display->printf(9, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%c", (weekdays[(wd - 1) * 2 + 1]));
+              switch (mode)
+              {
+              // Base line from Font
+              case 1:
+                this->config_->display->printf(1, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%d", d / 10 % 10);
+                this->config_->display->printf(8, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%d", d % 10);
+                break;
+              // Base line from Font
+              case 2:
+                this->config_->display->printf(1, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%d", d / 10 % 10);
+                this->config_->display->printf(9, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%d", d % 10);
+                break;
+              // Static Base line
+              case 3:
+                this->config_->display->printf(0, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%d", d / 10 % 10);
+                this->config_->display->printf(9, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%d", d % 10);
+                break;
+              // Static Base line
+              case 4:
+                this->config_->display->printf(1, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%d", d / 10 % 10);
+                this->config_->display->printf(8, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%d", d % 10);
+                break;
+              // Static Base line
+              case 5:
+                this->config_->display->printf(1, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%d", d / 10 % 10);
+                this->config_->display->printf(9, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%d", d % 10);
+                break;
+              // Base line from Font
+              default:
+                this->config_->display->printf(0, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%d", d / 10 % 10);
+                this->config_->display->printf(9, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%d", d % 10);
+                break;
+              }
+            }
+
+            if (this->icon_name.find("weekday") != std::string::npos)
+            {
+              // TODO: Added for testing for now, will need to rethink it [andrewjswan]
+              std::string weekdays = "SUMOTUWETHFRSA"; // F("SUMOTUWETHFRSA")
+              uint8_t wd = this->config_->clock->now().day_of_week;
+
+              switch (mode)
+              {
+              // Base line from Font
+              case 1:
+                this->config_->display->printf(1, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%c", (weekdays[(wd - 1) * 2]));
+                this->config_->display->printf(8, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%c", (weekdays[(wd - 1) * 2 + 1]));
+                break;
+              // Base line from Font
+              case 2:
+                this->config_->display->printf(1, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%c", (weekdays[(wd - 1) * 2]));
+                this->config_->display->printf(9, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%c", (weekdays[(wd - 1) * 2 + 1]));
+                break;
+              // Static Base line
+              case 3:
+                this->config_->display->printf(0, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%c", (weekdays[(wd - 1) * 2]));
+                this->config_->display->printf(9, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%c", (weekdays[(wd - 1) * 2 + 1]));
+                break;
+              // Static Base line
+              case 4:
+                this->config_->display->printf(1, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%c", (weekdays[(wd - 1) * 2]));
+                this->config_->display->printf(8, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%c", (weekdays[(wd - 1) * 2 + 1]));
+                break;
+              // Static Base line
+              case 5:
+                this->config_->display->printf(1, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%c", (weekdays[(wd - 1) * 2]));
+                this->config_->display->printf(9, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%c", (weekdays[(wd - 1) * 2 + 1]));
+                break;
+              // Base line from Font
+              default:
+                this->config_->display->printf(0, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%c", (weekdays[(wd - 1) * 2]));
+                this->config_->display->printf(9, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%c", (weekdays[(wd - 1) * 2 + 1]));
+                break;
+              }
+            }
           }
         }
         else

--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -253,10 +253,11 @@ namespace esphome
         }
 #endif
         break;
-      #ifdef USE_GRAPH
+#ifdef USE_GRAPH
       case MODE_GRAPH_SCREEN:
         this->config_->display->graph(0,0, this->config_->graph);
-    #endif
+        break;
+#endif
       case MODE_BITMAP_SMALL:
 #ifndef USE_ESP8266
         color_ = this->text_color;

--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -382,7 +382,7 @@ namespace esphome
             uint8_t d = this->config_->clock->now().day_of_month;
 
             this->config_->display->printf(0, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%d", d / 10 % 10);
-            this->config_->display->printf(7, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%d", d % 10);
+            this->config_->display->printf(9, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%d", d % 10);
           }
           if (this->icon_name == "weekday")
           {
@@ -391,7 +391,7 @@ namespace esphome
             uint8_t wd = this->config_->clock->now().day_of_week;
 
             this->config_->display->printf(0, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%c", (weekdays[(wd - 1) * 2]));
-            this->config_->display->printf(7, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%c", (weekdays[(wd - 1) * 2 + 1]));
+            this->config_->display->printf(9, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%c", (weekdays[(wd - 1) * 2 + 1]));
           }
         }
         else

--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -389,7 +389,6 @@ namespace esphome
               }
             }
 
-            // TODO: Add a color to display text on the icon 
             if (this->icon_name.find("day") != std::string::npos)
             {
               uint8_t d = this->config_->clock->now().day_of_month;
@@ -398,33 +397,33 @@ namespace esphome
               {
               // Base line from Font
               case 1:
-                this->config_->display->printf(1, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%d", d / 10 % 10);
-                this->config_->display->printf(8, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%d", d % 10);
+                this->config_->display->printf(1, yoffset, font, this->config_->info_lcolor, display::TextAlign::BASELINE_LEFT, "%d", d / 10 % 10);
+                this->config_->display->printf(8, yoffset, font, this->config_->info_rcolor, display::TextAlign::BASELINE_RIGHT, "%d", d % 10);
                 break;
               // Base line from Font
               case 2:
-                this->config_->display->printf(1, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%d", d / 10 % 10);
-                this->config_->display->printf(9, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%d", d % 10);
+                this->config_->display->printf(1, yoffset, font, this->config_->info_lcolor, display::TextAlign::BASELINE_LEFT, "%d", d / 10 % 10);
+                this->config_->display->printf(9, yoffset, font, this->config_->info_rcolor, display::TextAlign::BASELINE_RIGHT, "%d", d % 10);
                 break;
               // Static Base line
               case 3:
-                this->config_->display->printf(0, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%d", d / 10 % 10);
-                this->config_->display->printf(9, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%d", d % 10);
+                this->config_->display->printf(0, 7, font, this->config_->info_lcolor, display::TextAlign::BASELINE_LEFT, "%d", d / 10 % 10);
+                this->config_->display->printf(9, 7, font, this->config_->info_rcolor, display::TextAlign::BASELINE_RIGHT, "%d", d % 10);
                 break;
               // Static Base line
               case 4:
-                this->config_->display->printf(1, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%d", d / 10 % 10);
-                this->config_->display->printf(8, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%d", d % 10);
+                this->config_->display->printf(1, 7, font, this->config_->info_lcolor, display::TextAlign::BASELINE_LEFT, "%d", d / 10 % 10);
+                this->config_->display->printf(8, 7, font, this->config_->info_rcolor, display::TextAlign::BASELINE_RIGHT, "%d", d % 10);
                 break;
               // Static Base line
               case 5:
-                this->config_->display->printf(1, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%d", d / 10 % 10);
-                this->config_->display->printf(9, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%d", d % 10);
+                this->config_->display->printf(1, 7, font, this->config_->info_lcolor, display::TextAlign::BASELINE_LEFT, "%d", d / 10 % 10);
+                this->config_->display->printf(9, 7, font, this->config_->info_rcolor, display::TextAlign::BASELINE_RIGHT, "%d", d % 10);
                 break;
               // Base line from Font
               default:
-                this->config_->display->printf(0, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%d", d / 10 % 10);
-                this->config_->display->printf(9, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%d", d % 10);
+                this->config_->display->printf(0, yoffset, font, this->config_->info_lcolor, display::TextAlign::BASELINE_LEFT, "%d", d / 10 % 10);
+                this->config_->display->printf(9, yoffset, font, this->config_->info_rcolor, display::TextAlign::BASELINE_RIGHT, "%d", d % 10);
                 break;
               }
             }
@@ -439,33 +438,33 @@ namespace esphome
               {
               // Base line from Font
               case 1:
-                this->config_->display->printf(1, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%c", (weekdays[(wd - 1) * 2]));
-                this->config_->display->printf(8, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%c", (weekdays[(wd - 1) * 2 + 1]));
+                this->config_->display->printf(1, yoffset, font, this->config_->info_lcolor, display::TextAlign::BASELINE_LEFT, "%c", (weekdays[(wd - 1) * 2]));
+                this->config_->display->printf(8, yoffset, font, this->config_->info_rcolor, display::TextAlign::BASELINE_RIGHT, "%c", (weekdays[(wd - 1) * 2 + 1]));
                 break;
               // Base line from Font
               case 2:
-                this->config_->display->printf(1, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%c", (weekdays[(wd - 1) * 2]));
-                this->config_->display->printf(9, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%c", (weekdays[(wd - 1) * 2 + 1]));
+                this->config_->display->printf(1, yoffset, font, this->config_->info_lcolor, display::TextAlign::BASELINE_LEFT, "%c", (weekdays[(wd - 1) * 2]));
+                this->config_->display->printf(9, yoffset, font, this->config_->info_rcolor, display::TextAlign::BASELINE_RIGHT, "%c", (weekdays[(wd - 1) * 2 + 1]));
                 break;
               // Static Base line
               case 3:
-                this->config_->display->printf(0, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%c", (weekdays[(wd - 1) * 2]));
-                this->config_->display->printf(9, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%c", (weekdays[(wd - 1) * 2 + 1]));
+                this->config_->display->printf(0, 7, font, this->config_->info_lcolor, display::TextAlign::BASELINE_LEFT, "%c", (weekdays[(wd - 1) * 2]));
+                this->config_->display->printf(9, 7, font, this->config_->info_rcolor, display::TextAlign::BASELINE_RIGHT, "%c", (weekdays[(wd - 1) * 2 + 1]));
                 break;
               // Static Base line
               case 4:
-                this->config_->display->printf(1, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%c", (weekdays[(wd - 1) * 2]));
-                this->config_->display->printf(8, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%c", (weekdays[(wd - 1) * 2 + 1]));
+                this->config_->display->printf(1, 7, font, this->config_->info_lcolor, display::TextAlign::BASELINE_LEFT, "%c", (weekdays[(wd - 1) * 2]));
+                this->config_->display->printf(8, 7, font, this->config_->info_rcolor, display::TextAlign::BASELINE_RIGHT, "%c", (weekdays[(wd - 1) * 2 + 1]));
                 break;
               // Static Base line
               case 5:
-                this->config_->display->printf(1, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%c", (weekdays[(wd - 1) * 2]));
-                this->config_->display->printf(9, 7, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%c", (weekdays[(wd - 1) * 2 + 1]));
+                this->config_->display->printf(1, 7, font, this->config_->info_lcolor, display::TextAlign::BASELINE_LEFT, "%c", (weekdays[(wd - 1) * 2]));
+                this->config_->display->printf(9, 7, font, this->config_->info_rcolor, display::TextAlign::BASELINE_RIGHT, "%c", (weekdays[(wd - 1) * 2 + 1]));
                 break;
               // Base line from Font
               default:
-                this->config_->display->printf(0, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_LEFT, "%c", (weekdays[(wd - 1) * 2]));
-                this->config_->display->printf(9, yoffset, font, esphome::display::COLOR_OFF, display::TextAlign::BASELINE_RIGHT, "%c", (weekdays[(wd - 1) * 2 + 1]));
+                this->config_->display->printf(0, yoffset, font, this->config_->info_lcolor, display::TextAlign::BASELINE_LEFT, "%c", (weekdays[(wd - 1) * 2]));
+                this->config_->display->printf(9, yoffset, font, this->config_->info_rcolor, display::TextAlign::BASELINE_RIGHT, "%c", (weekdays[(wd - 1) * 2 + 1]));
                 break;
               }
             }

--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -74,7 +74,7 @@ namespace esphome
     this->last_time = 0;
     this->screen_time_ = 0;
     this->mode = MODE_EMPTY;
-    this->screen_id = "";
+    this->icon_name = "";
     this->icon = 0;
     this->text = "";
     this->default_font = true;
@@ -103,22 +103,22 @@ namespace esphome
       ESP_LOGD(TAG, "queue: graph for: %d sec", this->screen_time_);
       break;
     case MODE_FULL_SCREEN:
-      ESP_LOGD(TAG, "queue: full screen: \"%s\" for: %d sec", this->screen_id.c_str(), this->screen_time_);
+      ESP_LOGD(TAG, "queue: full screen: \"%s\" for: %d sec", this->icon_name.c_str(), this->screen_time_);
       break;
     case MODE_ICON_SCREEN:
-      ESP_LOGD(TAG, "queue: icon screen: \"%s\" text: %s for: %d sec", this->screen_id.c_str(), this->text.c_str(), this->screen_time_);
+      ESP_LOGD(TAG, "queue: icon screen: \"%s\" text: %s for: %d sec", this->icon_name.c_str(), this->text.c_str(), this->screen_time_);
       break;
     case MODE_ICON_CLOCK:
-      ESP_LOGD(TAG, "queue: icon \"%s\" for: %d sec", this->screen_id.c_str(), this->screen_time_);
+      ESP_LOGD(TAG, "queue: icon \"%s\" for: %d sec", this->icon_name.c_str(), this->screen_time_);
       break;
     case MODE_ALERT_SCREEN:
-      ESP_LOGD(TAG, "queue: icon \"%s\" for: %d sec", this->screen_id.c_str(), this->screen_time_);
+      ESP_LOGD(TAG, "queue: icon \"%s\" for: %d sec", this->icon_name.c_str(), this->screen_time_);
       break;
     case MODE_TEXT_SCREEN:
       ESP_LOGD(TAG, "queue: text text: \"%s\" for: %d sec", this->text.c_str(), this->screen_time_);
       break;
     case MODE_RAINBOW_ICON:
-      ESP_LOGD(TAG, "queue: rainbow icon: \"%s\" text: %s for: %d sec", this->screen_id.c_str(), this->text.c_str(), this->screen_time_);
+      ESP_LOGD(TAG, "queue: rainbow icon: \"%s\" text: %s for: %d sec", this->icon_name.c_str(), this->text.c_str(), this->screen_time_);
       break;
     case MODE_RAINBOW_TEXT:
       ESP_LOGD(TAG, "queue: rainbow text: \"%s\" for: %d sec", this->text.c_str(), this->screen_time_);

--- a/components/ehmtxv2/__init__.py
+++ b/components/ehmtxv2/__init__.py
@@ -115,6 +115,7 @@ CONF_WEEK_START_MONDAY = "week_start_monday"
 CONF_ICON = "icon_name"
 CONF_TEXT = "text"
 CONF_GRAPH = "display_graph"
+CONF_SCREEN = "screen_id"
 
 EHMTX_SCHEMA = cv.Schema({
     cv.Required(CONF_ID): cv.declare_id(EHMTX_),

--- a/components/ehmtxv2/__init__.py
+++ b/components/ehmtxv2/__init__.py
@@ -28,7 +28,7 @@ SVG_FULL_SCREEN_START = '<svg width="320px" height="80px" viewBox="0 0 320 80">'
 SVG_END = "</svg>"
 
 logging.warning(f"")
-logging.warning(f"!!!!This version (2023.8.0) has breaking changes!!!!")
+logging.warning(f"!!!!This version (2023.9.1) has breaking changes!!!!")
 logging.warning(f"Please check the documentation and wiki https://github.com/lubeda/EspHoMaTriXv2")
 logging.warning(f"This will only work with esphome >= 2023.7.0")
 logging.warning(f"")

--- a/components/ehmtxv2/__init__.py
+++ b/components/ehmtxv2/__init__.py
@@ -115,7 +115,6 @@ CONF_WEEK_START_MONDAY = "week_start_monday"
 CONF_ICON = "icon_name"
 CONF_TEXT = "text"
 CONF_GRAPH = "display_graph"
-CONF_SCREEN = "screen_id"
 
 EHMTX_SCHEMA = cv.Schema({
     cv.Required(CONF_ID): cv.declare_id(EHMTX_),


### PR DESCRIPTION
**2023.9.1**: Screen ID, Progress screen, Icon with Text
* Added the ability to specify a screen ID - `icon_name|screen_id`
* Added icon and date output screen - `icon_date(iconname, lifetime, screen_time, default_font, r, g, b)`
* If pass a screen identifier with the value `[day, weekday]` like `icon_name|day`, and a backing icon to `icon_clock` or `icon_date`, it will display text.
* Added a screen with the ability to display a progress bar, progress value (-100..100) - `icon_screen_progress(iconname, text, progress, lifetime, screen_time, default_font, r, g, b)`

Should solve the issues: https://github.com/lubeda/EspHoMaTriXv2/issues/83 https://github.com/lubeda/EspHoMaTriXv2/issues/91 https://github.com/lubeda/EspHoMaTriXv2/issues/92