### PR TITLE
Fix percent logging

### DIFF
--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -264,7 +264,7 @@ namespace esphome
         }
       }
       this->display_gauge = true;
-      ESP_LOGD(TAG, "show_gauge 2 color %d", round(percent));
+      ESP_LOGD(TAG, "show_gauge 2 color %d", percent);
     }
   }
 #else
@@ -278,7 +278,7 @@ namespace esphome
       this->display_gauge = true;
       this->gauge_value = (uint8_t)(100 - percent) * 7 / 100;
     }
-    ESP_LOGD(TAG, "show_gauge 2 color %d", round(percent));
+    ESP_LOGD(TAG, "show_gauge 2 color %d", percent);
   }
 #endif
 


### PR DESCRIPTION
```
In file included from src/esphome/components/sensor/sensor.h:3,
                 from src/esphome/components/adc/adc_sensor.h:6,
                 from src/esphome.h:3,
                 from src/esphome/components/ehmtxv2/EHMTX.cpp:1:
src/esphome/components/ehmtxv2/EHMTX.cpp: In member function 'void esphome::EHMTX::show_gauge(int, int, int, int, int, int, int)':
src/esphome/components/ehmtxv2/EHMTX.cpp:267:21: error: format '%d' expects argument of type 'int', but argument 5 has type 'double' [-Werror=format=]
       ESP_LOGD(TAG, "show_gauge 2 color %d", round(percent));
                     ^~~~~~~~~~~~~~~~~~~~~~~
src/esphome/core/log.h:72:36: note: in definition of macro 'ESPHOME_LOG_FORMAT'
 #define ESPHOME_LOG_FORMAT(format) format
                                    ^~~~~~
src/esphome/core/log.h:152:28: note: in expansion of macro 'esph_log_d'
 #define ESP_LOGD(tag, ...) esph_log_d(tag, __VA_ARGS__)
                            ^~~~~~~~~~
src/esphome/components/ehmtxv2/EHMTX.cpp:267:7: note: in expansion of macro 'ESP_LOGD'
       ESP_LOGD(TAG, "show_gauge 2 color %d", round(percent));
       ^~~~~~~~
cc1plus: some warnings being treated as errors
*** [.pioenvs/mobile-pixel-clock/src/esphome/components/ehmtxv2/EHMTX.o] Error 1
```