### PR TITLE
Moved char count for weekdays to init & edit typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For the old default behavior use this trigger in your YAML:
           id(rgb8x32)->date_screen(10,5);
 ```
 
-The `on_start_runnig`-trigger is called after the device boot once. The `on_empty_queue`-trigger is called when there is nothing in the queue. With the examples you will always have a clock and date displayed. If you don't like or want other colors e.t.c. feel free the change your YAML and have fun.
+The `on_start_running`-trigger is called after the device boot once. The `on_empty_queue`-trigger is called when there is nothing in the queue. With the examples you will always have a clock and date displayed. If you don't like or want other colors e.t.c. feel free the change your YAML and have fun.
 
 If you don't add this trigger you have a blank display until your hosts add screens via service calls.
 

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -552,7 +552,7 @@ namespace esphome
       if (this->night_mode)
       {
         bool skip = true;
-        for (auto id : EHMTXv2_CONF_NIGNT_MODE_SCREENS)
+        for (auto id : EHMTXv2_CONF_NIGHT_MODE_SCREENS)
         {
           if (this->queue[i]->mode == id)
           {
@@ -590,7 +590,7 @@ namespace esphome
         if (this->night_mode)
         {
           bool skip = true;
-          for (auto id : EHMTXv2_CONF_NIGNT_MODE_SCREENS)
+          for (auto id : EHMTXv2_CONF_NIGHT_MODE_SCREENS)
           {
             if (this->queue[i]->mode == id)
             {
@@ -1477,38 +1477,9 @@ namespace esphome
     }
   }
 
-  int EHMTX::GetWeekdayCharCount()
+  void EHMTX::set_weekday_char_count(uint8_t i)
   {
-    int count = 0;
-  
-    for (int i = 0; i < strlen(EHMTXv2_WEEKDAYTEXT);) 
-    {
-      if(EHMTXv2_WEEKDAYTEXT[i] & 0x80) 
-      {
-        if(EHMTXv2_WEEKDAYTEXT[i] & 0x20) 
-        {
-          if(EHMTXv2_WEEKDAYTEXT[i] & 0x10) 
-          {
-            i += 4;
-          } 
-          else 
-          {
-            i += 3;
-          }
-        } 
-        else 
-        {
-          i += 2;
-        }
-      }
-      else
-      {
-        i += 1;
-      }
-      count++;
-    }
-
-    return count;
+    this->weekday_char_count = i;
   }
 
   std::string EHMTX::GetWeekdayChar(int position)

--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -217,9 +217,10 @@ namespace esphome
     void draw_lindicator();
 
     void set_replace_time_date_active(bool b=false);
+    void set_weekday_char_count(uint8_t i);
     bool replace_time_date_active;
     std::string replace_time_date(std::string time_date);
-    int GetWeekdayCharCount();
+    uint8_t weekday_char_count;
     std::string GetWeekdayChar(int position);
 
     int GetTextBounds(esphome::display::BaseFont *font, const char *buffer);

--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -466,9 +466,8 @@ namespace esphome
             else // if (this->icon_name.rfind("weekday", 0) == 0)
             {
               uint8_t wd = this->config_->clock->now().day_of_week;
-              uint8_t weekday_count = this->config_->GetWeekdayCharCount();
 
-              if (weekday_count > 7)
+              if (this->config_->weekday_char_count > 7)
               {
                 std::string left = this->config_->GetWeekdayChar((wd - 1) * 2);
                 std::string right = this->config_->GetWeekdayChar((wd - 1) * 2 + 1);

--- a/components/ehmtxv2/__init__.py
+++ b/components/ehmtxv2/__init__.py
@@ -128,9 +128,8 @@ CONF_WEEK_START_MONDAY = "week_start_monday"
 CONF_ICON = "icon_name"
 CONF_TEXT = "text"
 CONF_GRAPH = "display_graph"
-CONF_NIGNT_MODE_SCREENS = "night_mode_screens"
-
-DAFAULT_NIGNT_MODE_SCREENS = [2,3,16]
+CONF_NIGHT_MODE_SCREENS = "night_mode_screens"
+DEFAULT_NIGHT_MODE_SCREENS = [2,3,16]
 
 EHMTX_SCHEMA = cv.Schema({
     cv.Required(CONF_ID): cv.declare_id(EHMTX_),
@@ -252,7 +251,7 @@ EHMTX_SCHEMA = cv.Schema({
             cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(NightModeTrigger),
         }
     ),
-    cv.Optional(CONF_NIGNT_MODE_SCREENS, default=DAFAULT_NIGNT_MODE_SCREENS): cv.All(
+    cv.Optional(CONF_NIGHT_MODE_SCREENS, default=DEFAULT_NIGHT_MODE_SCREENS): cv.All(
             cv.ensure_list(cv.one_of(1, 2, 3, 4, 5, 9, 10, 12, 13, 14, 15, 16, 17, 18, 19)), cv.Length(min=1, max=5)
         ),
     cv.Required(CONF_ICONS): cv.All(
@@ -462,8 +461,16 @@ async def to_code(config):
         cg.add_define("EHMTXv2_ALWAYS_SHOW_RLINDICATORS")
 
     if config[CONF_WEEKDAYTEXT]:
-        cg.add_define("EHMTXv2_WEEKDAYTEXT",config[CONF_WEEKDAYTEXT])
+        if (len(config[CONF_WEEKDAYTEXT])) == 7:
+            cg.add(var.set_weekday_char_count(7))
 
+        elif (len(config[CONF_WEEKDAYTEXT])) == 14:
+            cg.add(var.set_weekday_char_count(14))
+        else:
+            logging.warning(f"weekdays: must be 7 or 14 characters... your config may have unpredictable results!\n\r")
+            cg.add(var.set_weekday_char_count(len(config[CONF_WEEKDAYTEXT])))
+
+    cg.add_define("EHMTXv2_WEEKDAYTEXT",config[CONF_WEEKDAYTEXT])
     cg.add_define("EHMTXv2_REPLACE_TIME_DATE_TO",config[CONF_REPLACE_TIME_DATE_TO])
     cg.add_define("EHMTXv2_REPLACE_TIME_DATE_FROM",config[CONF_REPLACE_TIME_DATE_FROM])
 
@@ -507,8 +514,8 @@ async def to_code(config):
     if config[CONF_RTL]:
         cg.add_define("EHMTXv2_USE_RTL")    
     
-    if config[CONF_NIGNT_MODE_SCREENS]:
-        cg.add_define("EHMTXv2_CONF_NIGNT_MODE_SCREENS",config[CONF_NIGNT_MODE_SCREENS])
+    if config[CONF_NIGHT_MODE_SCREENS]:
+        cg.add_define("EHMTXv2_CONF_NIGHT_MODE_SCREENS",config[CONF_NIGHT_MODE_SCREENS])
 
     cg.add(var.set_show_day_of_week(config[CONF_SHOWDOW]))  
 


### PR DESCRIPTION
The character count for weekdays could be moved to the `__init__.py` instead of before which iterated through the string just to count the characters... a permanent variable set is set during compile and then used instead.

Also, fixed some typos to do with Night Mode (in all files)... and a little one in the readme.
