### PR TITLE
2023.9.1: Fix for screen_id when only iconname defined

### DIFF
--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -174,7 +174,7 @@ namespace esphome
       }
     }
 
-    return (tokens.size() > 1) ? tokens[1] : (tokens.size() > 0) ? get_icon_name(tokens[0], '_') : "";
+    return (tokens.size() > 1) ? tokens[1] : (tokens.size() > 0) ? (iconname.find("*") != std::string::npos) ? get_icon_name(tokens[0], '_') : tokens[0] : "";
   }
 
 #ifndef USE_ESP8266


### PR DESCRIPTION
2023.9.1: Fix for screen_id when only iconname defined and iconname with `_` sign.
