### PR TITLE
2023.9.1: Added accent for days of week

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - Added `bitmap_stack`screen. Screen that allows you to display from 1 to 64 icons described in the configuration.
 - Added a screen with the ability to display a progress bar, text, progress value `(-100..100)`
   - `text_screen_progress(text, value, progress, lifetime, screen_time, default_font, value_color_as_progress, r, g, b)`
+- Added `set_weekday_accent_on` and `set_weekday_accent_off` Turn on / off small days (accent) of the week when brightness is insufficient.
 
 ### EspHoMaTriX 2023.9.0
 - Added the ability to display graph as defined in the YAML file
@@ -747,6 +748,8 @@ Numerous features are accessible with services from home assistant and lambdas t
 |`set_today_color`|"r", "g", "b"|set the special color for today in the day of week line|
 |`set_weekday_color`|"r", "g", "b"|set the default color in the day of week line|
 |`set_clock_color`|"r", "g", "b"|set the default color of clock and date display|
+|`set_weekday_accent_on`|none|turns on the display of small days (accent) of the week when brightness is insufficient|
+|`set_weekday_accent_off`|none|turns off the display of small days (accent) of the week when brightness is insufficient|
 |`del_screen`|"icon_name", “mode”|deletes the specified icon screen from the queue, the [mode](#modes) is a filter|
 |`force_screen`|"icon_name", “mode”|displays the selected the specified icon screen from the queue, the [mode](#modes) is a filter|
 |`full_screen`|"icon_name", "lifetime", "screen_time"|show the specified 8x32 icon as full screen|

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -27,6 +27,7 @@ namespace esphome
     this->set_today_color();
     this->set_weekday_color();
     this->night_mode = false;
+    this->weekday_accent = false;
 
     for (uint8_t i = 0; i < MAXQUEUE; i++)
     {
@@ -118,6 +119,18 @@ namespace esphome
     {
       t->process(this->night_mode);
     }
+  }
+
+  void EHMTX::set_weekday_accent_off()
+  {
+    this->weekday_accent = false;
+    ESP_LOGD(TAG, "weekday accent off");
+  }
+
+  void EHMTX::set_weekday_accent_on()
+  {
+    this->weekday_accent = true;
+    ESP_LOGD(TAG, "weekday accent on");
   }
 
   void EHMTX::set_today_color(int r, int g, int b)
@@ -597,6 +610,9 @@ namespace esphome
 
     register_service(&EHMTX::set_night_mode_on, "night_mode_on");
     register_service(&EHMTX::set_night_mode_off, "night_mode_off");
+
+    register_service(&EHMTX::set_weekday_accent_on, "weekday_accent_on");
+    register_service(&EHMTX::set_weekday_accent_off, "weekday_accent_off");
 
     register_service(&EHMTX::del_screen, "del_screen", {"icon_name", "mode"});
     register_service(&EHMTX::force_screen, "force_screen", {"icon_name", "mode"});
@@ -1092,6 +1108,7 @@ namespace esphome
     ESP_LOGI(TAG, "status date format: %s", EHMTXv2_DATE_FORMAT);
     ESP_LOGI(TAG, "status display %s", this->show_display ? F("on") : F("off"));
     ESP_LOGI(TAG, "status night mode %s", this->night_mode ? F("on") : F("off"));
+    ESP_LOGI(TAG, "status weekday accent %s", this->weekday_accent ? F("on") : F("off"));
     ESP_LOGI(TAG, "status replace time and date %s", this->replace_time_date_active ? F("on") : F("off"));
 
     this->queue_status();
@@ -1766,6 +1783,7 @@ namespace esphome
     this->display = disp;
     this->show_display = true;
     this->night_mode = false;
+    this->weekday_accent = false;
     ESP_LOGD(TAG, "set_display");
   }
 
@@ -1856,7 +1874,7 @@ namespace esphome
           else
           {
             this->display->line(2 + i * 4, 7, i * 4 + 4, 7, this->weekday_color);
-            if (this->brightness_ < 50)
+            if (this->weekday_accent && this->brightness_ < 50)
             {
               this->display->line(i * 4 + 3, 7, i * 4 + 3, 7, this->today_color);
             }
@@ -1873,7 +1891,7 @@ namespace esphome
           else
           {          
             this->display->line(10 + i * 3, 7, 11 + i * 3 , 7, this->weekday_color);
-            if (this->brightness_ < 50)
+            if (this->weekday_accent && this->brightness_ < 50)
             {
               this->display->line( (i < dow ? 11 : 10) + i * 3, 7, (i < dow ? 11 : 10) + i * 3 , 7, this->today_color);
             }
@@ -2002,6 +2020,7 @@ namespace esphome
     ESP_LOGCONFIG(TAG, "Weekdays: %s Count: %d", EHMTXv2_WEEKDAYTEXT, this->weekday_char_count);
     ESP_LOGCONFIG(TAG, "Display: %s", this->show_display ? F("On") : F("Off"));
     ESP_LOGCONFIG(TAG, "Night mode: %s", this->night_mode ? F("On") : F("Off"));
+    ESP_LOGCONFIG(TAG, "Weekday accent: %s", this->weekday_accent ? F("On") : F("Off"));
     ESP_LOGCONFIG(TAG, "Replace Time and Date: %s", this->replace_time_date_active ? F("On") : F("Off"));
     if (this->replace_time_date_active) {
       ESP_LOGCONFIG(TAG, "Replace from: %s", EHMTXv2_REPLACE_TIME_DATE_FROM);

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -1856,6 +1856,10 @@ namespace esphome
           else
           {
             this->display->line(2 + i * 4, 7, i * 4 + 4, 7, this->weekday_color);
+            if (this->brightness_ < 50)
+            {
+              this->display->line(i * 4 + 3, 7, i * 4 + 3, 7, this->today_color);
+            }
           }
         }
       } else {
@@ -1869,6 +1873,10 @@ namespace esphome
           else
           {          
             this->display->line(10 + i * 3, 7, 11 + i * 3 , 7, this->weekday_color);
+            if (this->brightness_ < 50)
+            {
+              this->display->line( (i < dow ? 11 : 10) + i * 3, 7, (i < dow ? 11 : 10) + i * 3 , 7, this->today_color);
+            }
           }
         }
       }

--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -158,6 +158,7 @@ namespace esphome
     void add_icon(EHMTX_Icon *icon);
     bool show_display = false;
     bool night_mode = false;
+    bool weekday_accent = false;
     uint8_t find_icon(std::string name);
     uint8_t find_last_clock();
     bool string_has_ending(std::string const &fullString, std::string const &ending);
@@ -179,6 +180,8 @@ namespace esphome
     void set_display_off();
     void set_night_mode_off();
     void set_night_mode_on();
+    void set_weekday_accent_off();
+    void set_weekday_accent_on();
     void set_clock(esphome::time::RealTimeClock *clock);
     #ifdef USE_GRAPH
       void set_graph(esphome::graph::Graph *graph);


### PR DESCRIPTION
In the dark, it is very difficult to tell the time of the week as you can only see the current streak of the day, but this way it will be clear what day it is in any light.