### PR TITLE
2023.9.1: Add advanced Bitmap mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 - Added `vertical_scroll` to ehmtxv2 config.
 - Added Advanced clock mode `advanced_clock`, [More info](https://github.com/lubeda/EspHoMaTriXv2/issues/164)
 - Added `icon_indicator`, Shows the indicator in the Icons area on the specified screens, in the specified color and at the specified vertical position. [Example](https://github.com/lubeda/EspHoMaTriXv2/pull/170#issuecomment-1836539171)
+- Added Advanced Bitmap mode `advanced_bitmap`, [More info](#advanced-bitmap-mode)
 
 ### EspHoMaTriX 2023.9.0
 - Added the ability to display graph as defined in the YAML file
@@ -658,6 +659,8 @@ ehmtxv2:
 **time_format_big** (optional, string): formats the date display with [strftime syntax](https://esphome.io/components/time.html?highlight=strftime), defaults `"%H:%M:%S"`, work only in **advanced_clock** mode and sets the time format for a screen with a clock without an icon
 
 **advanced_clock** (optional, boolean): Enables or disables advanced clock mode. (default: false) [More info](https://github.com/lubeda/EspHoMaTriXv2/issues/164)
+
+**advanced_bitmap**  (optional, boolean): Enables or disables advanced clock mode. (default: false) [More info](#advanced-bitmap-mode)
 
 **default_font_yoffset** (optional, pixel): yoffset the text is aligned BASELINE_LEFT, the baseline defaults to `6`
 
@@ -1434,6 +1437,16 @@ data:
 ```
 
 It's easier to see what it looks like than to describe it, try both options, choose the one that suits you best.
+
+### Advanced Bitmap mode
+
+Enables advanced mode of Bitmap screen (MODE_BITMAP_SCREEN), allows the use of [screen identifiers](#screen_id), which in turn makes it possible to display more than one Bitmap screen on the clock. But it can also increase RAM consumption, each screen + 256 bytes.
+
+```
+ehmtxv2:
+  advanced_bitmap: true
+```
+
 
 ## Breaking changes
 

--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -57,7 +57,8 @@ enum show_mode : uint8_t
   MODE_BITMAP_STACK_SCREEN = 23,
   MODE_TEXT_PROGRESS = 24,
   MODE_PROGNOSIS_SCREEN = 25,
-  MODE_BITMAP_TEXTSCREEN = 27
+  MODE_RAINBOW_ALERT_SCREEN = 26,
+  MODE_BITMAP_TEXT_SCREEN = 27
 };
 
 namespace esphome
@@ -232,6 +233,7 @@ namespace esphome
     void full_screen(std::string icon, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME);
     void icon_screen(std::string icon, std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
     void alert_screen(std::string icon, std::string text, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = CA_RED, int g = CA_GREEN, int b = CA_BLUE);
+    void rainbow_alert_screen(std::string icon, std::string text, int screen_time = D_SCREEN_TIME, bool default_font = true);
     void icon_clock(std::string icon, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
     void icon_date(std::string icon, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
     void text_screen(std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);

--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -57,8 +57,7 @@ enum show_mode : uint8_t
   MODE_BITMAP_STACK_SCREEN = 23,
   MODE_TEXT_PROGRESS = 24,
   MODE_PROGNOSIS_SCREEN = 25,
-  MODE_RAINBOW_ALERT_SCREEN = 26,
-  MODE_BITMAP_TEXT_SCREEN = 27
+  MODE_RAINBOW_ALERT_SCREEN = 26
 };
 
 namespace esphome
@@ -254,9 +253,6 @@ namespace esphome
     void icon_prognosis_screen_rgb(std::string icon, std::string text, std::string prognosis, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
 
     void bitmap_screen(std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME);
-    #ifdef EHMTXv2_ADV_BITMAP
-    void bitmap_text_screen(std::string bitmap, std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
-    #endif
     void color_gauge(std::string text);
     void bitmap_small(std::string icon, std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
     void rainbow_bitmap_small(std::string icon, std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true);

--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -56,7 +56,8 @@ enum show_mode : uint8_t
   MODE_RAINBOW_ICON_TEXT_SCREEN = 22,
   MODE_BITMAP_STACK_SCREEN = 23,
   MODE_TEXT_PROGRESS = 24,
-  MODE_PROGNOSIS_SCREEN = 25
+  MODE_PROGNOSIS_SCREEN = 25,
+  MODE_BITMAP_TEXTSCREEN = 27
 };
 
 namespace esphome
@@ -115,7 +116,9 @@ namespace esphome
   #endif
 #ifdef USE_ESP32
     PROGMEM Color text_color, alarm_color, rindicator_color, lindicator_color, today_color, weekday_color, rainbow_color, clock_color, info_lcolor, info_rcolor, icon_indicator_color;
+  #ifndef EHMTXv2_ADV_BITMAP
     PROGMEM Color bitmap[256];
+  #endif
     PROGMEM Color cgauge[8];
     PROGMEM EHMTX_Icon *icons[MAXICONS];
   #ifdef EHMTXv2_ADV_CLOCK
@@ -249,6 +252,9 @@ namespace esphome
     void icon_prognosis_screen_rgb(std::string icon, std::string text, std::string prognosis, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
 
     void bitmap_screen(std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME);
+    #ifdef EHMTXv2_ADV_BITMAP
+    void bitmap_text_screen(std::string bitmap, std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
+    #endif
     void color_gauge(std::string text);
     void bitmap_small(std::string icon, std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
     void rainbow_bitmap_small(std::string icon, std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true);
@@ -308,6 +314,9 @@ namespace esphome
     show_mode mode;
     int8_t progress;
     Color* sbitmap;
+  #ifdef EHMTXv2_ADV_BITMAP
+    Color* bitmap;
+  #endif
 
 #ifdef USE_ESP32
     PROGMEM Color text_color, progressbar_color, progressbar_back_color;

--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -80,6 +80,9 @@ namespace esphome
     this->default_font = true;
     this->progress = 0;
     this->sbitmap = nullptr;
+    #ifdef EHMTXv2_ADV_BITMAP
+    this->bitmap = nullptr;
+    #endif
     this->progressbar_color = esphome::display::COLOR_OFF;
     this->progressbar_back_color = esphome::display::COLOR_OFF;
   }
@@ -162,11 +165,6 @@ namespace esphome
     case MODE_BITMAP_SCREEN:
       ESP_LOGD(TAG, "queue: bitmap for: %.1f sec", this->screen_time_ / 1000.0);
       break;
-    #ifdef EHMTXv2_ADV_BITMAP
-    case MODE_BITMAP_TEXT_SCREEN:
-      ESP_LOGD(TAG, "queue: bitmap text for: %.1f sec", this->screen_time_ / 1000.0);
-      break;
-    #endif
     case MODE_BITMAP_SMALL:
       ESP_LOGD(TAG, "queue: small bitmap for: %.1f sec", this->screen_time_ / 1000.0);
       break;
@@ -467,44 +465,14 @@ namespace esphome
         {
           for (uint8_t y = 0; y < 8; y++)
           {
-              #ifdef EHMTXv2_ADV_BITMAP
+            #ifdef EHMTXv2_ADV_BITMAP
               this->config_->display->draw_pixel_at(x, this->ypos() + y, this->bitmap[x + y * 32]);
-              #else
-            this->config_->display->draw_pixel_at(x, this->ypos() + y, this->config_->bitmap[x + y * 32]);
-              #endif
+            #else
+              this->config_->display->draw_pixel_at(x, this->ypos() + y, this->config_->bitmap[x + y * 32]);
+            #endif
             }
           }
         #ifdef EHMTXv2_ADV_BITMAP
-        }
-        #endif
-#endif
-        break;
-      case MODE_BITMAP_TEXT_SCREEN:
-#ifndef USE_ESP8266
-        #ifdef EHMTXv2_ADV_BITMAP
-        if (this->config_->get_tick() - this->last_time < screen_time_ / 2.0)
-        {
-          if (this->bitmap != NULL)
-          {
-            for (uint8_t x = 0; x < 32; x++)
-            {
-              for (uint8_t y = 0; y < 8; y++)
-              {
-                this->config_->display->draw_pixel_at(x, this->ypos() + y, this->bitmap[x + y * 32]);
-              }
-            }
-          }
-        }
-        else
-        {
-          color_ = (this->mode == MODE_RAINBOW_TEXT) ? this->config_->rainbow_color : this->text_color;
-          #ifdef EHMTXv2_USE_RTL
-          this->config_->display->print(this->xpos() + xoffset, this->ypos() + yoffset, font, color_, esphome::display::TextAlign::BASELINE_RIGHT,
-                                        this->text.c_str());
-          #else
-          this->config_->display->print(this->xpos() + xoffset, this->ypos() + yoffset, font, color_, esphome::display::TextAlign::BASELINE_LEFT,
-                                        this->text.c_str());
-          #endif
         }
         #endif
 #endif
@@ -1089,7 +1057,6 @@ namespace esphome
     {
     case MODE_TEXT_SCREEN:
     case MODE_RAINBOW_TEXT:
-    case MODE_BITMAP_TEXT_SCREEN:
 #ifdef EHMTXv2_SCROLL_SMALL_TEXT
       max_steps = EHMTXv2_SCROLL_COUNT * (width - startx) + EHMTXv2_SCROLL_COUNT * this->pixels_;
       display_duration = static_cast<float>(max_steps * EHMTXv2_SCROLL_INTERVALL);
@@ -1105,13 +1072,6 @@ namespace esphome
         display_duration = static_cast<float>(max_steps * EHMTXv2_SCROLL_INTERVALL);
         this->screen_time_ = (display_duration > requested_time) ? display_duration : requested_time;
       }
-      #ifdef EHMTXv2_ADV_BITMAP
-      if (this->mode == MODE_BITMAP_TEXT_SCREEN)
-      {
-        display_duration = display_duration * 2.0;
-        this->screen_time_ = (display_duration > requested_time) ? display_duration : requested_time;
-      }
-      #endif
 #endif
       break;
     case MODE_RAINBOW_ICON:

--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -128,7 +128,10 @@ namespace esphome
       ESP_LOGD(TAG, "queue: icon date: \"%s\" for: %.1f sec", this->icon_name.c_str(), this->screen_time_ / 1000.0);
       break;
     case MODE_ALERT_SCREEN:
-      ESP_LOGD(TAG, "queue: icon: \"%s\" for: %.1f sec", this->icon_name.c_str(), this->screen_time_ / 1000.0);
+      ESP_LOGD(TAG, "queue: alert icon: \"%s\" for: %.1f sec", this->icon_name.c_str(), this->screen_time_ / 1000.0);
+      break;
+    case MODE_RAINBOW_ALERT_SCREEN:
+      ESP_LOGD(TAG, "queue: rainbow alert icon: \"%s\" for: %.1f sec", this->icon_name.c_str(), this->screen_time_ / 1000.0);
       break;
     case MODE_TEXT_SCREEN:
       ESP_LOGD(TAG, "queue: text text: \"%s\" for: %.1f sec", this->text.c_str(), this->screen_time_ / 1000.0);
@@ -195,6 +198,7 @@ namespace esphome
     case MODE_ICON_CLOCK:
     case MODE_ICON_DATE:
     case MODE_ALERT_SCREEN:
+    case MODE_RAINBOW_ALERT_SCREEN:
     case MODE_ICON_PROGRESS:
     case MODE_PROGNOSIS_SCREEN:
       startx = 8;
@@ -459,14 +463,14 @@ namespace esphome
         if (this->bitmap != NULL)
         {
         #endif
-          for (uint8_t x = 0; x < 32; x++)
+        for (uint8_t x = 0; x < 32; x++)
+        {
+          for (uint8_t y = 0; y < 8; y++)
           {
-            for (uint8_t y = 0; y < 8; y++)
-            {
               #ifdef EHMTXv2_ADV_BITMAP
               this->config_->display->draw_pixel_at(x, this->ypos() + y, this->bitmap[x + y * 32]);
               #else
-              this->config_->display->draw_pixel_at(x, this->ypos() + y, this->config_->bitmap[x + y * 32]);
+            this->config_->display->draw_pixel_at(x, this->ypos() + y, this->config_->bitmap[x + y * 32]);
               #endif
             }
           }
@@ -478,7 +482,7 @@ namespace esphome
       case MODE_BITMAP_TEXT_SCREEN:
 #ifndef USE_ESP8266
         #ifdef EHMTXv2_ADV_BITMAP
-        if (this->config_->get_tick() - this->last_time < screen_time_ / 2.0);
+        if (this->config_->get_tick() - this->last_time < screen_time_ / 2.0)
         {
           if (this->bitmap != NULL)
           {
@@ -812,10 +816,11 @@ namespace esphome
 
       case MODE_ICON_SCREEN:
       case MODE_ALERT_SCREEN:
+      case MODE_RAINBOW_ALERT_SCREEN:
       case MODE_RAINBOW_ICON:
       case MODE_ICON_PROGRESS:
       case MODE_PROGNOSIS_SCREEN:
-        color_ = (this->mode == MODE_RAINBOW_ICON) ? this->config_->rainbow_color : this->text_color;
+        color_ = (this->mode == MODE_RAINBOW_ICON || this->mode == MODE_RAINBOW_ALERT_SCREEN) ? this->config_->rainbow_color : this->text_color;
 #ifdef EHMTXv2_USE_RTL
         this->config_->display->print(this->xpos() + xoffset, this->ypos() + yoffset, font, color_, esphome::display::TextAlign::BASELINE_RIGHT,
                                       this->text.c_str());
@@ -1084,7 +1089,7 @@ namespace esphome
     {
     case MODE_TEXT_SCREEN:
     case MODE_RAINBOW_TEXT:
-    case MODE_BITMAP_TEXTSCREEN:
+    case MODE_BITMAP_TEXT_SCREEN:
 #ifdef EHMTXv2_SCROLL_SMALL_TEXT
       max_steps = EHMTXv2_SCROLL_COUNT * (width - startx) + EHMTXv2_SCROLL_COUNT * this->pixels_;
       display_duration = static_cast<float>(max_steps * EHMTXv2_SCROLL_INTERVALL);
@@ -1101,7 +1106,7 @@ namespace esphome
         this->screen_time_ = (display_duration > requested_time) ? display_duration : requested_time;
       }
       #ifdef EHMTXv2_ADV_BITMAP
-      if (this->mode == MODE_BITMAP_TEXTSCREEN)
+      if (this->mode == MODE_BITMAP_TEXT_SCREEN)
       {
         display_duration = display_duration * 2.0;
         this->screen_time_ = (display_duration > requested_time) ? display_duration : requested_time;
@@ -1114,6 +1119,7 @@ namespace esphome
     case MODE_RAINBOW_BITMAP_SMALL:
     case MODE_ICON_SCREEN:
     case MODE_ALERT_SCREEN:
+    case MODE_RAINBOW_ALERT_SCREEN:
     case MODE_ICON_PROGRESS:
     case MODE_PROGNOSIS_SCREEN:
       startx = 8;

--- a/components/ehmtxv2/__init__.py
+++ b/components/ehmtxv2/__init__.py
@@ -97,6 +97,7 @@ CONF_SHOWDOW = "show_dow"
 CONF_RTL = "rtl"
 CONF_VERTICAL = "vertical_scroll"
 CONF_CLOCK = "advanced_clock"
+CONF_BITMAP = "advanced_bitmap"
 CONF_FRAMEDURATION = "frame_duration"
 CONF_SCROLLCOUNT = "scroll_count"
 CONF_MATRIXCOMPONENT = "matrix_component"
@@ -164,6 +165,9 @@ EHMTX_SCHEMA = cv.Schema({
     ): cv.boolean,
      cv.Optional(
         CONF_CLOCK, default=False
+    ): cv.boolean,
+     cv.Optional(
+        CONF_BITMAP, default=False
     ): cv.boolean,
     cv.Optional(
         CONF_SHOW_SECONDS, default=False
@@ -575,6 +579,9 @@ async def to_code(config):
     
     if config[CONF_CLOCK]:
         cg.add_define("EHMTXv2_ADV_CLOCK")    
+
+    if config[CONF_BITMAP]:
+        cg.add_define("EHMTXv2_ADV_BITMAP")    
 
     if config[CONF_NIGHT_MODE_SCREENS]:
         cg.add_define("EHMTXv2_CONF_NIGHT_MODE_SCREENS",config[CONF_NIGHT_MODE_SCREENS])

--- a/components/ehmtxv2/__init__.py
+++ b/components/ehmtxv2/__init__.py
@@ -166,7 +166,7 @@ EHMTX_SCHEMA = cv.Schema({
      cv.Optional(
         CONF_CLOCK, default=False
     ): cv.boolean,
-     cv.Optional(
+    cv.Optional(
         CONF_BITMAP, default=False
     ): cv.boolean,
     cv.Optional(


### PR DESCRIPTION
Advanced mode of Bitmap screen (MODE_BITMAP_SCREEN), allows the use of screen identifiers, which in turn makes it possible to display more than one Bitmap screen on the clock.
But it can also increase RAM consumption, each screen + 256 bytes.