### PR TITLE
2023.9.1: Expand Icon to 9 pixels

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,7 +800,7 @@ Numerous features are accessible with services from home assistant and lambdas t
 |`set_clock_infotext_color`|"left_r", "left_g", "left_b", "right_r", "right_g", "right_b","default_font","y_offset"|set the special color for left and right char on info text on `icon clock` screen, work only in **advanced clock mode**|
 |`show_icon_indicator`|"r", "g", "b", "size", "pos"|shows the line indicator in the Icons area on the specified screens, in the specified color and at the specified vertical position|
 |`hide_icon_indicator`|none|hides the icon indicator|
-|`expand_icon_to_9`|"mode"|Extends the icon display on the clock screen and date screen by one line (9 pixels wide). Mode 0 (default) - do not expand. Mode 1 - expand only on the clock screen. Mode 2 - expand only on the date screen. Mode 3 - expand on the screen with clock and on the screen with date.|
+|`expand_icon_to_9`|"mode"|Extends the icon display on the clock screen and date screen by one line (9 pixels wide). Mode 0 (default) - do not expand. Mode 1 - expand only on the clock screen. Mode 2 - expand only on the date screen. Mode 3 - expand on the screen with clock and on the screen with date. [More info](https://github.com/lubeda/EspHoMaTriXv2/pull/179)|
 
 #### Parameter description
 
@@ -1438,6 +1438,36 @@ data:
 ```
 
 It's easier to see what it looks like than to describe it, try both options, choose the one that suits you best.
+
+### Select for Expand Icon to 9
+
+```
+select:
+  - platform: template
+    name: "Expand icon to 9"
+    optimistic: true
+    options:
+      - "not"
+      - "clock"
+      - "date"
+      - "clock and date"
+    restore_value: true
+    on_value:
+      then:
+        - lambda: |-
+            if (x == "not") {
+              id(rgb8x32)->expand_icon_to_9(0);
+            }
+            else if (x == "clock"){
+              id(rgb8x32)->expand_icon_to_9(1);
+            }
+            else if (x == "date"){
+              id(rgb8x32)->expand_icon_to_9(2);
+            }
+            else if (x == "clock and date"){
+              id(rgb8x32)->expand_icon_to_9(3);
+            }
+```
 
 ## Breaking changes
 

--- a/README.md
+++ b/README.md
@@ -800,6 +800,7 @@ Numerous features are accessible with services from home assistant and lambdas t
 |`set_clock_infotext_color`|"left_r", "left_g", "left_b", "right_r", "right_g", "right_b","default_font","y_offset"|set the special color for left and right char on info text on `icon clock` screen, work only in **advanced clock mode**|
 |`show_icon_indicator`|"r", "g", "b", "size", "pos"|shows the line indicator in the Icons area on the specified screens, in the specified color and at the specified vertical position|
 |`hide_icon_indicator`|none|hides the icon indicator|
+|`expand_icon_to_9`|"mode"|Extends the icon display on the clock screen and date screen by one line (9 pixels wide). Mode 0 (default) - do not expand. Mode 1 - expand only on the clock screen. Mode 2 - expand only on the date screen. Mode 3 - expand on the screen with clock and on the screen with date.|
 
 #### Parameter description
 

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -16,6 +16,7 @@ namespace esphome
     this->display_lindicator = 0;
     this->display_icon_indicator = 0;
     this->icon_indicator_y_pos = 7;
+    this->icon_to_9 = 0;
     this->display_alarm = 0;
     this->clock_time = 10;
     this->icon_count = 0;
@@ -179,6 +180,12 @@ namespace esphome
   {
     this->weekday_color = Color((uint8_t)r , (uint8_t)g , (uint8_t)b );
     ESP_LOGD(TAG, "default weekday color: %d g: %d b: %d", r, g, b);
+  }
+
+  void EHMTX::expand_icon_to_9(int mode)
+  {
+    this->icon_to_9 = mode;
+    ESP_LOGD(TAG, "icon expanded to 9 mode: %d", mode);
   }
 
   bool EHMTX::string_has_ending(std::string const &fullString, std::string const &ending)
@@ -647,6 +654,7 @@ namespace esphome
     register_service(&EHMTX::set_clock_color, "set_clock_color", {"r", "g", "b"});
     register_service(&EHMTX::set_text_color, "set_text_color", {"r", "g", "b"});
     register_service(&EHMTX::set_infotext_color, "set_infotext_color", {"left_r", "left_g", "left_b", "right_r", "right_g", "right_b", "default_font", "y_offset"});
+    register_service(&EHMTX::expand_icon_to_9, "expand_icon_to_9", {"mode"});
 
     register_service(&EHMTX::set_night_mode_on, "night_mode_on");
     register_service(&EHMTX::set_night_mode_off, "night_mode_off");

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -2508,8 +2508,8 @@ namespace esphome
               (this->queue[this->screen_pointer]->mode == MODE_ICON_DATE  && this->icon_to_9 == 2) ||
               (this->icon_to_9 == 3))
           {
-            this->display->line(5 - ceil(display_icon_indicator / 2), this->icon_indicator_y_pos, 
-                                3 + ceil(display_icon_indicator / 2), this->icon_indicator_y_pos, 
+            this->display->line(4 - display_icon_indicator / 2, this->icon_indicator_y_pos, 
+                                4 + display_icon_indicator / 2, this->icon_indicator_y_pos, 
                                 this->icon_indicator_color);
           }
           else

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -2508,7 +2508,7 @@ namespace esphome
               (this->queue[this->screen_pointer]->mode == MODE_ICON_DATE  && this->icon_to_9 == 2) ||
               (this->icon_to_9 == 3))
           {
-            this->display->line(5 - display_icon_indicator / 2, this->icon_indicator_y_pos, 
+            this->display->line(4 - display_icon_indicator / 2, this->icon_indicator_y_pos, 
                                 4 + display_icon_indicator / 2, this->icon_indicator_y_pos, 
                                 this->icon_indicator_color);
           }

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -2508,8 +2508,8 @@ namespace esphome
               (this->queue[this->screen_pointer]->mode == MODE_ICON_DATE  && this->icon_to_9 == 2) ||
               (this->icon_to_9 == 3))
           {
-            this->display->line(4 - display_icon_indicator / 2, this->icon_indicator_y_pos, 
-                                4 + display_icon_indicator / 2, this->icon_indicator_y_pos, 
+            this->display->line(5 - ceil(display_icon_indicator / 2), this->icon_indicator_y_pos, 
+                                3 + ceil(display_icon_indicator / 2), this->icon_indicator_y_pos, 
                                 this->icon_indicator_color);
           }
           else

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -2204,19 +2204,21 @@ namespace esphome
       }
       else 
       {
+        uint8_t off_l = (this->icon_to_9 == 3) ? 11 : 10;
+        uint8_t off_r = (this->icon_to_9 == 3) ? 12 : 11;
         for (uint8_t i = 0; i <= 6; i++)
         {
           if (((!EHMTXv2_WEEK_START) && (dow == i)) ||
               ((EHMTXv2_WEEK_START) && ((dow == (i + 1)) || ((dow == 0 && i == 6)))))
           {
-            this->display->line(10 + i * 3, ypos + 7, 11 + i * 3, ypos + 7, this->today_color);
+            this->display->line(off_l + i * 3, ypos + 7, off_r + i * 3, ypos + 7, this->today_color);
           }
           else
           {          
-            this->display->line(10 + i * 3, ypos + 7, 11 + i * 3, ypos + 7, this->weekday_color);
+            this->display->line(off_l + i * 3, ypos + 7, off_r + i * 3, ypos + 7, this->weekday_color);
             if (accent_color != esphome::display::COLOR_OFF)
             {
-              this->display->line( (i < dow ? 11 : 10) + i * 3, ypos + 7, (i < dow ? 11 : 10) + i * 3, ypos + 7, accent_color);
+              this->display->line( (i < dow ? off_r : off_l) + i * 3, ypos + 7, (i < dow ? off_r : off_l) + i * 3, ypos + 7, accent_color);
             }
           }
         }

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -2504,9 +2504,20 @@ namespace esphome
       {
         if (this->queue[this->screen_pointer]->mode == id)
         {
-          this->display->line(4 - display_icon_indicator / 2, this->icon_indicator_y_pos, 
-                              3 + display_icon_indicator / 2, this->icon_indicator_y_pos, 
-                              this->icon_indicator_color);
+          if ((this->queue[this->screen_pointer]->mode == MODE_ICON_CLOCK && this->icon_to_9 == 1) ||
+              (this->queue[this->screen_pointer]->mode == MODE_ICON_DATE  && this->icon_to_9 == 2) ||
+              (this->icon_to_9 == 3))
+          {
+            this->display->line(5 - display_icon_indicator / 2, this->icon_indicator_y_pos, 
+                                4 + display_icon_indicator / 2, this->icon_indicator_y_pos, 
+                                this->icon_indicator_color);
+          }
+          else
+          {
+            this->display->line(4 - display_icon_indicator / 2, this->icon_indicator_y_pos, 
+                                3 + display_icon_indicator / 2, this->icon_indicator_y_pos, 
+                                this->icon_indicator_color);
+          }
           break;
         }
       }

--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -110,6 +110,7 @@ namespace esphome
     bool info_font = true;
     int8_t info_y_offset = 0;
     int8_t icon_indicator_y_pos = 7;
+    uint8_t icon_to_9 = 0;
   #ifdef EHMTXv2_ADV_CLOCK
     bool info_clock_font = true;
     int8_t info_clock_y_offset = 0;
@@ -199,6 +200,7 @@ namespace esphome
     void set_night_mode_on();
     void set_weekday_accent_off();
     void set_weekday_accent_on();
+    void expand_icon_to_9(int mode=0);
     void set_clock(esphome::time::RealTimeClock *clock);
     #ifdef USE_GRAPH
       void set_graph(esphome::graph::Graph *graph);

--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -638,6 +638,12 @@ namespace esphome
           }
           if (this->icon != BLANKICON)
           {
+            if ((this->mode == MODE_ICON_CLOCK && this->config_->icon_to_9 == 1) ||
+                (this->mode == MODE_ICON_DATE  && this->config_->icon_to_9 == 2) ||
+                (this->config_->icon_to_9 == 3))
+            {
+              this->config_->display->image(1, this->ypos(), this->config_->icons[this->icon]);
+            }
             this->config_->display->image(0, this->ypos(), this->config_->icons[this->icon]);
           }
           this->config_->draw_day_of_week(this->ypos(), true);

--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -600,6 +600,7 @@ namespace esphome
         {
           color_ = this->text_color;
           time_t ts = this->config_->clock->now().timestamp;
+          uint8_t offset = (this->config_->icon_to_9 == 3) ? 21 : 20;
 
           if (this->mode == MODE_ICON_CLOCK)
           {
@@ -611,11 +612,11 @@ namespace esphome
               {
                 std::string time_new = this->config_->clock->now().strftime(EHMTXv2_TIME_FORMAT).c_str();
                 time_new = this->config_->replace_time_date(time_new);
-                this->config_->display->printf(xoffset + 20, this->ypos() + yoffset, font, color_, display::TextAlign::BASELINE_CENTER, "%s", time_new.c_str());
+                this->config_->display->printf(xoffset + offset, this->ypos() + yoffset, font, color_, display::TextAlign::BASELINE_CENTER, "%s", time_new.c_str());
               } 
               else 
               {
-                this->config_->display->strftime(xoffset + 20, this->ypos() + yoffset, font, color_, display::TextAlign::BASELINE_CENTER, EHMTXv2_TIME_FORMAT,
+                this->config_->display->strftime(xoffset + offset, this->ypos() + yoffset, font, color_, display::TextAlign::BASELINE_CENTER, EHMTXv2_TIME_FORMAT,
                                                  this->config_->clock->now());
               }
             #ifdef EHMTXv2_ADV_CLOCK
@@ -628,11 +629,11 @@ namespace esphome
             {
               std::string time_new = this->config_->clock->now().strftime(EHMTXv2_DATE_FORMAT).c_str();
               time_new = this->config_->replace_time_date(time_new);
-              this->config_->display->printf(xoffset + 20, this->ypos() + yoffset, font, color_, display::TextAlign::BASELINE_CENTER, "%s", time_new.c_str());
+              this->config_->display->printf(xoffset + offset, this->ypos() + yoffset, font, color_, display::TextAlign::BASELINE_CENTER, "%s", time_new.c_str());
             } 
             else 
             {
-              this->config_->display->strftime(xoffset + 20, this->ypos() + yoffset, font, color_, display::TextAlign::BASELINE_CENTER, EHMTXv2_DATE_FORMAT,
+              this->config_->display->strftime(xoffset + offset, this->ypos() + yoffset, font, color_, display::TextAlign::BASELINE_CENTER, EHMTXv2_DATE_FORMAT,
                                                this->config_->clock->now());
             }
           }


### PR DESCRIPTION
Extends the icon display on the clock screen and date screen by one line (9 pixels wide). 
Convenient for displaying the current date with a distance of one pixel between numbers, visual harmony. 
Mode 0 (default) - do not expand. 
Mode 1 - expand only on the clock screen. 
Mode 2 - expand only on the date screen. 
Mode 3 - expand on the screen with clock and on the screen with date.