### PR TITLE
2023.9.1: Add pseudo icon - solid and calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 - Added `icon_indicator`, Shows the indicator in the Icons area on the specified screens, in the specified color and at the specified vertical position. [Example](https://github.com/lubeda/EspHoMaTriXv2/pull/170#issuecomment-1836539171)
 - Added `rainbow_alert_screen`, show the specified icon with text in rainbow color, screen forced and lifetime = screen_time
 - Added a pseudo-icon `solid` - icon as square filled with solid color, see `set_solid_color`.
+- Added a pseudo-icon `calendar` - calendar icon with default whitecolor, and header as color from `set_calendar_color`.
 - Added Advanced Bitmap mode `advanced_bitmap`, [More info](#advanced-bitmap-mode)
 
 ### EspHoMaTriX 2023.9.0
@@ -770,6 +771,7 @@ Numerous features are accessible with services from home assistant and lambdas t
 |`set_weekday_color`|"r", "g", "b"|set the default color in the day of week line|
 |`set_clock_color`|"r", "g", "b"|set the default color of clock and date display|
 |`set_solid_color`|"r", "g", "b"|set the color for solid pseudo icon|
+|`set_calendar_color`|"r", "g", "b"|set the header color for calendar pseudo icon|
 |`set_weekday_accent_on`|none|turns on the display of small days (accent) of the week when brightness is insufficient|
 |`set_weekday_accent_off`|none|turns off the display of small days (accent) of the week when brightness is insufficient|
 |`del_screen`|"icon_name", “mode”|deletes the specified icon screen from the queue, the [mode](#modes) is a filter|
@@ -812,7 +814,7 @@ Numerous features are accessible with services from home assistant and lambdas t
 - **r, g, b**: Color components for red, green, and blue 0..255
 - **size**: The size of the rindicator or alarm, 1-3
 - **percent**: values from 0..100
-- **icon_name**: the id of the icon to show, as defined in the YAML file (or pseudo-icon `blank` - empty icon, `solid` - solid icon), it is also possible to set the arbitrary [screen identifier](#screen_id), for example `icon_name|screen_id`
+- **icon_name**: the id of the icon to show, as defined in the YAML file (or pseudo-icon `blank` - empty icon, `solid` - solid icon, `calendar` - calendar icon), it is also possible to set the arbitrary [screen identifier](#screen_id), for example `icon_name|screen_id`
 - **icons**: the list of id of the icon to show, as defined in the YAML file, like: icon1,icon2.
 - **text**: a text message to display
 - **lifetime**: how long does this screen stay in the queue (minutes)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 - Added Advanced clock mode `advanced_clock`, [More info](https://github.com/lubeda/EspHoMaTriXv2/issues/164)
 - Added `icon_indicator`, Shows the indicator in the Icons area on the specified screens, in the specified color and at the specified vertical position. [Example](https://github.com/lubeda/EspHoMaTriXv2/pull/170#issuecomment-1836539171)
 - Added `rainbow_alert_screen`, show the specified icon with text in rainbow color, screen forced and lifetime = screen_time
+- Added a pseudo-icon `solid` - icon as square filled with solid color, see `set_solid_color`.
 
 ### EspHoMaTriX 2023.9.0
 - Added the ability to display graph as defined in the YAML file
@@ -765,6 +766,7 @@ Numerous features are accessible with services from home assistant and lambdas t
 |`set_today_color`|"r", "g", "b"|set the special color for today in the day of week line|
 |`set_weekday_color`|"r", "g", "b"|set the default color in the day of week line|
 |`set_clock_color`|"r", "g", "b"|set the default color of clock and date display|
+|`set_solid_color`|"r", "g", "b"|set the color for solid pseudo icon|
 |`set_weekday_accent_on`|none|turns on the display of small days (accent) of the week when brightness is insufficient|
 |`set_weekday_accent_off`|none|turns off the display of small days (accent) of the week when brightness is insufficient|
 |`del_screen`|"icon_name", “mode”|deletes the specified icon screen from the queue, the [mode](#modes) is a filter|
@@ -807,7 +809,7 @@ Numerous features are accessible with services from home assistant and lambdas t
 - **r, g, b**: Color components for red, green, and blue 0..255
 - **size**: The size of the rindicator or alarm, 1-3
 - **percent**: values from 0..100
-- **icon_name**: the id of the icon to show, as defined in the YAML file (or pseudo-icon `blank` - empty icon), it is also possible to set the arbitrary [screen identifier](#screen_id), for example `icon_name|screen_id`
+- **icon_name**: the id of the icon to show, as defined in the YAML file (or pseudo-icon `blank` - empty icon, `solid` - solid icon), it is also possible to set the arbitrary [screen identifier](#screen_id), for example `icon_name|screen_id`
 - **icons**: the list of id of the icon to show, as defined in the YAML file, like: icon1,icon2.
 - **text**: a text message to display
 - **lifetime**: how long does this screen stay in the queue (minutes)

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -24,6 +24,7 @@ namespace esphome
     this->rainbow_color = Color(CA_RED, CA_GREEN, CA_BLUE);
     this->info_lcolor = Color(CG_GREY, CG_GREY, CG_GREY);
     this->info_rcolor = Color(CG_GREY * 2, CG_GREY * 2, CG_GREY * 2);
+    this->solid_color = Color(C_RED, C_GREEN, C_BLUE);
     this->next_action_time = 0.0;
     this->last_scroll_time = 0;
     this->screen_pointer = MAXQUEUE;
@@ -518,6 +519,11 @@ namespace esphome
       return BLANKICON;
     }
 
+    if (name == "solid")
+    {
+      return SOLIDICON;
+    }
+
     for (uint8_t i = 0; i < this->icon_count; i++)
     {
       if (strcmp(this->icons[i]->name.c_str(), name.c_str()) == 0)
@@ -656,6 +662,8 @@ namespace esphome
     register_service(&EHMTX::set_infotext_color, "set_infotext_color", {"left_r", "left_g", "left_b", "right_r", "right_g", "right_b", "default_font", "y_offset"});
     register_service(&EHMTX::expand_icon_to_9, "expand_icon_to_9", {"mode"});
 
+    register_service(&EHMTX::set_solid_color, "set_solid_color", {"r", "g", "b"});
+
     register_service(&EHMTX::set_night_mode_on, "night_mode_on");
     register_service(&EHMTX::set_night_mode_off, "night_mode_off");
 
@@ -774,6 +782,12 @@ namespace esphome
     this->info_font = df;
     this->info_y_offset = y_offset;
     ESP_LOGD(TAG, "info text color left: r: %d g: %d b: %d right: r: %d g: %d b: %d y_offset %d", lr, lg, lb, rr, rg, rb, y_offset);
+  }
+
+  void EHMTX::set_solid_color(int r, int g, int b)
+  {
+    this->solid_color = Color((uint8_t)r, (uint8_t)g, (uint8_t)b);
+    ESP_LOGD(TAG, "solid icon color r: %d g: %d b: %d", r, g, b);
   }
 
   void EHMTX::update() // called from polling component

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -25,6 +25,7 @@ namespace esphome
     this->info_lcolor = Color(CG_GREY, CG_GREY, CG_GREY);
     this->info_rcolor = Color(CG_GREY * 2, CG_GREY * 2, CG_GREY * 2);
     this->solid_color = Color(C_RED, C_GREEN, C_BLUE);
+    this->calendar_color = Color(C_RED, C_BLACK, C_BLACK);
     this->next_action_time = 0.0;
     this->last_scroll_time = 0;
     this->screen_pointer = MAXQUEUE;
@@ -548,6 +549,11 @@ namespace esphome
       return SOLIDICON;
     }
 
+    if (name == "calendar")
+    {
+      return CALENDARICON;
+    }
+
     for (uint8_t i = 0; i < this->icon_count; i++)
     {
       if (strcmp(this->icons[i]->name.c_str(), name.c_str()) == 0)
@@ -687,6 +693,7 @@ namespace esphome
     register_service(&EHMTX::expand_icon_to_9, "expand_icon_to_9", {"mode"});
 
     register_service(&EHMTX::set_solid_color, "set_solid_color", {"r", "g", "b"});
+    register_service(&EHMTX::set_calendar_color, "set_calendar_color", {"r", "g", "b"});
 
     register_service(&EHMTX::set_night_mode_on, "night_mode_on");
     register_service(&EHMTX::set_night_mode_off, "night_mode_off");
@@ -812,6 +819,12 @@ namespace esphome
   {
     this->solid_color = Color((uint8_t)r, (uint8_t)g, (uint8_t)b);
     ESP_LOGD(TAG, "solid icon color r: %d g: %d b: %d", r, g, b);
+  }
+
+  void EHMTX::set_calendar_color(int r, int g, int b)
+  {
+    this->calendar_color = Color((uint8_t)r, (uint8_t)g, (uint8_t)b);
+    ESP_LOGD(TAG, "calendar icon color r: %d g: %d b: %d", r, g, b);
   }
 
   void EHMTX::update() // called from polling component

--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -23,6 +23,7 @@ const uint8_t D_SCREEN_TIME = 10;
 const uint8_t MAXICONS = 90;
 const uint8_t BLANKICON = MAXICONS + 1;
 const uint8_t SOLIDICON = MAXICONS + 3;
+const uint8_t CALENDARICON = MAXICONS + 5;
 const uint8_t TEXTSCROLLSTART = 8;
 const uint8_t TEXTSTARTOFFSET = (32 - 8);
 
@@ -117,7 +118,7 @@ namespace esphome
     int8_t info_clock_y_offset = 0;
   #endif
 #ifdef USE_ESP32
-    PROGMEM Color text_color, alarm_color, rindicator_color, lindicator_color, today_color, weekday_color, rainbow_color, clock_color, info_lcolor, info_rcolor, icon_indicator_color, solid_color;
+    PROGMEM Color text_color, alarm_color, rindicator_color, lindicator_color, today_color, weekday_color, rainbow_color, clock_color, info_lcolor, info_rcolor, icon_indicator_color, solid_color, calendar_color;
   #ifndef EHMTXv2_ADV_BITMAP
     PROGMEM Color bitmap[256];
   #endif
@@ -129,7 +130,7 @@ namespace esphome
 #endif
 
 #ifdef USE_ESP8266
-    Color text_color, alarm_color, gauge_color, gauge_bgcolor, rindicator_color, lindicator_color, today_color, weekday_color, rainbow_color, clock_color, info_lcolor, info_rcolor, icon_indicator_color, solid_color;
+    Color text_color, alarm_color, gauge_color, gauge_bgcolor, rindicator_color, lindicator_color, today_color, weekday_color, rainbow_color, clock_color, info_lcolor, info_rcolor, icon_indicator_color, solid_color, calendar_color;
     EHMTX_Icon *icons[MAXICONS];
     uint8_t gauge_value;
   #ifdef EHMTXv2_ADV_CLOCK
@@ -220,6 +221,7 @@ namespace esphome
     void set_clock_color(int r = C_RED, int g = C_GREEN, int b = C_BLUE);
     void set_infotext_color(int lr = CG_GREY, int lg = CG_GREY, int lb = CG_GREY, int rr = CG_GREY, int rg = CG_GREY, int rb = CG_GREY, bool info_font = true, int y_offset = 0);
     void set_solid_color(int r = C_RED, int g = C_GREEN, int b = C_BLUE);
+    void set_calendar_color(int r = C_RED, int g = C_BLACK, int b = C_BLACK);
     #ifdef EHMTXv2_ADV_CLOCK
       void set_clock_infotext_color(int lr = CG_GREY, int lg = CG_GREY, int lb = CG_GREY, int rr = CG_GREY, int rg = CG_GREY, int rb = CG_GREY, bool info_font = true, int y_offset = 0);
       void set_adv_clock_color(int hr = C_BLACK, int hg = C_BLACK, int hb = C_BLACK, int mr = C_BLACK, int mg = C_BLACK, int mb = C_BLACK, int sr = C_BLACK, int sg = C_BLACK, int sb = C_BLACK);

--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -22,6 +22,7 @@ const uint8_t D_SCREEN_TIME = 10;
 
 const uint8_t MAXICONS = 90;
 const uint8_t BLANKICON = MAXICONS + 1;
+const uint8_t SOLIDICON = MAXICONS + 3;
 const uint8_t TEXTSCROLLSTART = 8;
 const uint8_t TEXTSTARTOFFSET = (32 - 8);
 
@@ -116,7 +117,7 @@ namespace esphome
     int8_t info_clock_y_offset = 0;
   #endif
 #ifdef USE_ESP32
-    PROGMEM Color text_color, alarm_color, rindicator_color, lindicator_color, today_color, weekday_color, rainbow_color, clock_color, info_lcolor, info_rcolor, icon_indicator_color;
+    PROGMEM Color text_color, alarm_color, rindicator_color, lindicator_color, today_color, weekday_color, rainbow_color, clock_color, info_lcolor, info_rcolor, icon_indicator_color, solid_color;
     PROGMEM Color bitmap[256];
     PROGMEM Color cgauge[8];
     PROGMEM EHMTX_Icon *icons[MAXICONS];
@@ -126,7 +127,7 @@ namespace esphome
 #endif
 
 #ifdef USE_ESP8266
-    Color text_color, alarm_color, gauge_color, gauge_bgcolor, rindicator_color, lindicator_color, today_color, weekday_color, rainbow_color, clock_color, info_lcolor, info_rcolor, icon_indicator_color;
+    Color text_color, alarm_color, gauge_color, gauge_bgcolor, rindicator_color, lindicator_color, today_color, weekday_color, rainbow_color, clock_color, info_lcolor, info_rcolor, icon_indicator_color, solid_color;
     EHMTX_Icon *icons[MAXICONS];
     uint8_t gauge_value;
   #ifdef EHMTXv2_ADV_CLOCK
@@ -216,6 +217,7 @@ namespace esphome
     void set_weekday_color(int r = CD_RED, int g = CD_GREEN, int b = CD_BLUE);
     void set_clock_color(int r = C_RED, int g = C_GREEN, int b = C_BLUE);
     void set_infotext_color(int lr = CG_GREY, int lg = CG_GREY, int lb = CG_GREY, int rr = CG_GREY, int rg = CG_GREY, int rb = CG_GREY, bool info_font = true, int y_offset = 0);
+    void set_solid_color(int r = C_RED, int g = C_GREEN, int b = C_BLUE);
     #ifdef EHMTXv2_ADV_CLOCK
       void set_clock_infotext_color(int lr = CG_GREY, int lg = CG_GREY, int lb = CG_GREY, int rr = CG_GREY, int rg = CG_GREY, int rb = CG_GREY, bool info_font = true, int y_offset = 0);
       void set_adv_clock_color(int hr = C_BLACK, int hg = C_BLACK, int hb = C_BLACK, int mr = C_BLACK, int mg = C_BLACK, int mb = C_BLACK, int sr = C_BLACK, int sg = C_BLACK, int sb = C_BLACK);

--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -494,6 +494,11 @@ namespace esphome
             {
               this->config_->display->filled_rectangle(0, this->ypos(), 8, 8, this->config_->solid_color); 
             }
+            else if (this->icon == CALENDARICON)
+            {
+              this->config_->display->filled_rectangle(0, this->ypos(), 8, 8, Color(C_RED, C_GREEN, C_BLUE)); 
+              this->config_->display->filled_rectangle(0, this->ypos(), 8, 2, this->config_->calendar_color); 
+            }
             else
             {
               this->config_->display->image(0, this->ypos(), this->config_->icons[this->icon]);
@@ -673,6 +678,21 @@ namespace esphome
                 this->config_->display->filled_rectangle(0, this->ypos(), 8, 8, this->config_->solid_color); 
               }
             }
+            else if (this->icon == CALENDARICON)
+            {
+              if ((this->mode == MODE_ICON_CLOCK && this->config_->icon_to_9 == 1) ||
+                  (this->mode == MODE_ICON_DATE  && this->config_->icon_to_9 == 2) ||
+                  (this->config_->icon_to_9 == 3))
+              {
+                this->config_->display->filled_rectangle(0, this->ypos(), 9, 8, Color(C_RED, C_GREEN, C_BLUE)); 
+                this->config_->display->filled_rectangle(0, this->ypos(), 9, 2, this->config_->calendar_color); 
+              }
+              else
+              {
+                this->config_->display->filled_rectangle(0, this->ypos(), 8, 8, Color(C_RED, C_GREEN, C_BLUE)); 
+                this->config_->display->filled_rectangle(0, this->ypos(), 8, 2, this->config_->calendar_color); 
+              }
+            }
             else
             {
               if ((this->mode == MODE_ICON_CLOCK && this->config_->icon_to_9 == 1) ||
@@ -835,6 +855,11 @@ namespace esphome
             {
               this->config_->display->filled_rectangle(0, this->ypos(), 8, 8, this->config_->solid_color); 
             }
+            else if (this->icon == CALENDARICON)
+            {
+              this->config_->display->filled_rectangle(0, this->ypos(), 8, 8, Color(C_RED, C_GREEN, C_BLUE)); 
+              this->config_->display->filled_rectangle(0, this->ypos(), 8, 2, this->config_->calendar_color); 
+            }
             else
             {
               this->config_->display->image(0, this->ypos(), this->config_->icons[this->icon]);
@@ -864,6 +889,11 @@ namespace esphome
             {
               this->config_->display->filled_rectangle(0, this->ypos(), 8, 8, this->config_->solid_color); 
             }
+            else if (this->icon == CALENDARICON)
+            {
+              this->config_->display->filled_rectangle(0, this->ypos(), 8, 8, Color(C_RED, C_GREEN, C_BLUE)); 
+              this->config_->display->filled_rectangle(0, this->ypos(), 8, 2, this->config_->calendar_color); 
+            }
             else
             {
               this->config_->display->image(0, this->ypos(), this->config_->icons[this->icon]);
@@ -888,6 +918,11 @@ namespace esphome
               {
                 this->config_->display->filled_rectangle(2, this->ypos(), 8, 8, this->config_->solid_color); 
               }
+              else if (this->icon == CALENDARICON)
+              {
+                this->config_->display->filled_rectangle(2, this->ypos(), 8, 8, Color(C_RED, C_GREEN, C_BLUE)); 
+                this->config_->display->filled_rectangle(2, this->ypos(), 8, 2, this->config_->calendar_color); 
+              }
               else
               {
                 this->config_->display->image(2, this->ypos(), this->config_->icons[this->icon]);
@@ -903,6 +938,11 @@ namespace esphome
               if (this->icon == SOLIDICON)
               {
                 this->config_->display->filled_rectangle(0, this->ypos(), 8, 8, this->config_->solid_color); 
+              }
+              else if (this->icon == CALENDARICON)
+              {
+                this->config_->display->filled_rectangle(0, this->ypos(), 8, 8, Color(C_RED, C_GREEN, C_BLUE)); 
+                this->config_->display->filled_rectangle(0, this->ypos(), 8, 2, this->config_->calendar_color); 
               }
               else
               {
@@ -971,6 +1011,11 @@ namespace esphome
           {
             this->config_->display->filled_rectangle(x, this->ypos(), 8, 8, this->config_->solid_color); 
           }
+          else if (this->icon == CALENDARICON)
+          {
+            this->config_->display->filled_rectangle(x, this->ypos(), 8, 8, Color(C_RED, C_GREEN, C_BLUE)); 
+            this->config_->display->filled_rectangle(x, this->ypos(), 8, 2, this->config_->calendar_color); 
+          }
           else
           {
             this->config_->display->image(x, this->ypos(), this->config_->icons[this->icon]);
@@ -1001,6 +1046,11 @@ namespace esphome
               if (this->icon == SOLIDICON)
               {
                 this->config_->display->filled_rectangle(this->xpos(i), this->ypos(i), 8, 8, this->config_->solid_color); 
+              }
+              else if (this->icon == CALENDARICON)
+              {
+                this->config_->display->filled_rectangle(this->xpos(i), this->ypos(), 8, 8, Color(C_RED, C_GREEN, C_BLUE)); 
+                this->config_->display->filled_rectangle(this->xpos(i), this->ypos(), 8, 2, this->config_->calendar_color); 
               }
               else
               {

--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -476,7 +476,14 @@ namespace esphome
           if (this->icon != BLANKICON)
           {
             this->config_->display->line(8, this->ypos(), 8, this->ypos() + 7, esphome::display::COLOR_OFF);
-            this->config_->display->image(0, this->ypos(), this->config_->icons[this->icon]);
+            if (this->icon == SOLIDICON)
+            {
+              this->config_->display->filled_rectangle(0, this->ypos(), 8, 8, this->config_->solid_color); 
+            }
+            else
+            {
+              this->config_->display->image(0, this->ypos(), this->config_->icons[this->icon]);
+            }
           }
         }
         break;
@@ -639,13 +646,29 @@ namespace esphome
           }
           if (this->icon != BLANKICON)
           {
-            if ((this->mode == MODE_ICON_CLOCK && this->config_->icon_to_9 == 1) ||
-                (this->mode == MODE_ICON_DATE  && this->config_->icon_to_9 == 2) ||
-                (this->config_->icon_to_9 == 3))
+            if (this->icon == SOLIDICON)
             {
-              this->config_->display->image(1, this->ypos(), this->config_->icons[this->icon]);
+              if ((this->mode == MODE_ICON_CLOCK && this->config_->icon_to_9 == 1) ||
+                  (this->mode == MODE_ICON_DATE  && this->config_->icon_to_9 == 2) ||
+                  (this->config_->icon_to_9 == 3))
+              {
+                this->config_->display->filled_rectangle(0, this->ypos(), 9, 8, this->config_->solid_color); 
+              }
+              else
+              {
+                this->config_->display->filled_rectangle(0, this->ypos(), 8, 8, this->config_->solid_color); 
+              }
             }
-            this->config_->display->image(0, this->ypos(), this->config_->icons[this->icon]);
+            else
+            {
+              if ((this->mode == MODE_ICON_CLOCK && this->config_->icon_to_9 == 1) ||
+                  (this->mode == MODE_ICON_DATE  && this->config_->icon_to_9 == 2) ||
+                  (this->config_->icon_to_9 == 3))
+              {
+                this->config_->display->image(1, this->ypos(), this->config_->icons[this->icon]);
+              }
+              this->config_->display->image(0, this->ypos(), this->config_->icons[this->icon]);
+            }
           }
           this->config_->draw_day_of_week(this->ypos(), true);
 
@@ -794,7 +817,14 @@ namespace esphome
           if (this->icon != BLANKICON)
           {
             this->config_->display->line(8, this->ypos(), 8, this->ypos() + 7, esphome::display::COLOR_OFF);
-            this->config_->display->image(0, this->ypos(), this->config_->icons[this->icon]);
+            if (this->icon == SOLIDICON)
+            {
+              this->config_->display->filled_rectangle(0, this->ypos(), 8, 8, this->config_->solid_color); 
+            }
+            else
+            {
+              this->config_->display->image(0, this->ypos(), this->config_->icons[this->icon]);
+            }
           }
 
           this->config_->display->line(9, this->ypos() + 7, 31, this->ypos() + 7, this->progressbar_back_color);
@@ -816,7 +846,14 @@ namespace esphome
           if (this->icon != BLANKICON)
           {
             this->config_->display->line(8, this->ypos(), 8, this->ypos() + 7, esphome::display::COLOR_OFF);
-            this->config_->display->image(0, this->ypos(), this->config_->icons[this->icon]);
+            if (this->icon == SOLIDICON)
+            {
+              this->config_->display->filled_rectangle(0, this->ypos(), 8, 8, this->config_->solid_color); 
+            }
+            else
+            {
+              this->config_->display->image(0, this->ypos(), this->config_->icons[this->icon]);
+            }
           }
 
           if (this->sbitmap != NULL)
@@ -833,7 +870,14 @@ namespace esphome
           {
             if (this->icon != BLANKICON)
             {
-              this->config_->display->image(2, this->ypos(), this->config_->icons[this->icon]);
+              if (this->icon == SOLIDICON)
+              {
+                this->config_->display->filled_rectangle(2, this->ypos(), 8, 8, this->config_->solid_color); 
+              }
+              else
+              {
+                this->config_->display->image(2, this->ypos(), this->config_->icons[this->icon]);
+              }
             }
             this->config_->display->line(10, this->ypos(), 10, this->ypos() + 7, esphome::display::COLOR_OFF);
           }
@@ -842,7 +886,14 @@ namespace esphome
             this->config_->display->line(8, this->ypos(), 8, this->ypos() + 7, esphome::display::COLOR_OFF);
             if (this->icon != BLANKICON)
             {
-              this->config_->display->image(0, this->ypos(), this->config_->icons[this->icon]);
+              if (this->icon == SOLIDICON)
+              {
+                this->config_->display->filled_rectangle(0, this->ypos(), 8, 8, this->config_->solid_color); 
+              }
+              else
+              {
+                this->config_->display->image(0, this->ypos(), this->config_->icons[this->icon]);
+              }
             }
           }
         }
@@ -902,7 +953,14 @@ namespace esphome
             }
           }
           this->config_->display->line(x + 8, this->ypos(), x + 8, this->ypos() + 7, esphome::display::COLOR_OFF);
-          this->config_->display->image(x, this->ypos(), this->config_->icons[this->icon]);
+          if (this->icon == SOLIDICON)
+          {
+            this->config_->display->filled_rectangle(x, this->ypos(), 8, 8, this->config_->solid_color); 
+          }
+          else
+          {
+            this->config_->display->image(x, this->ypos(), this->config_->icons[this->icon]);
+          }
         }
         break;
 
@@ -926,7 +984,14 @@ namespace esphome
           {
             if (this->sbitmap[i].b != BLANKICON)
             {
-              this->config_->display->image(this->xpos(i), this->ypos(i), this->config_->icons[this->sbitmap[i].b]);
+              if (this->icon == SOLIDICON)
+              {
+                this->config_->display->filled_rectangle(this->xpos(i), this->ypos(i), 8, 8, this->config_->solid_color); 
+              }
+              else
+              {
+                this->config_->display->image(this->xpos(i), this->ypos(i), this->config_->icons[this->sbitmap[i].b]);
+              }
             }
           }
         }


### PR DESCRIPTION
Pseudo-icon `solid` - icon as square filled with solid color, see `set_solid_color`.
Pseudo-icon `calendar` - calendar icon with default white color, and header as color from `set_calendar_color`.
