### PR TITLE
2024.1.0: Advanced Boot Logo

### DIFF
--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -35,10 +35,17 @@ namespace esphome
     this->set_weekday_color();
     this->night_mode = false;
     this->weekday_accent = false;
+
     #ifdef EHMTXv2_USE_VERTICAL_SCROLL
       this->vertical_scroll = false;
     #endif
 
+    #ifdef USE_ESP32
+    #ifdef EHMTXv2_ADV_BOOT
+      this->boot_logo = nullptr;
+    #endif
+    #endif
+    
     for (uint8_t i = 0; i < MAXQUEUE; i++)
     {
       this->queue[i] = new EHMTX_queue(this);
@@ -1326,7 +1333,7 @@ namespace esphome
       #ifdef EHMTXv2_ADV_BOOT
       if (this->boot_logo != NULL)
       {
-        if (this->boot_anim % 10 == 0)
+        if (this->boot_anim % EHMTXv2_RAINBOW_INTERVALL == 0)
         {
           for (uint8_t x = 0; x < 32; x++)
           {

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -1323,10 +1323,25 @@ namespace esphome
     }
     else
     {
-      uint8_t w = 2 + ((uint8_t)(32 / 16) * (this->boot_anim / 16)) % 32;
-      uint8_t l = 32 / 2 - w / 2 ;
-      this->display->rectangle(l, 2, w, 4, this->rainbow_color); 
-      this->boot_anim++;
+      #ifdef EHMTXv2_ADV_BOOT
+      if (this->boot_logo != NULL) 
+      {
+        for (uint8_t x = 0; x < 32; x++)
+        {
+          for (uint8_t y = 0; y < 8; y++)
+          {
+            this->display->draw_pixel_at(x, y, this->rainbow_color);
+          }
+        }        
+      }
+      else
+      #endif
+      {
+        uint8_t w = 2 + ((uint8_t)(32 / 16) * (this->boot_anim / 16)) % 32;
+        uint8_t l = 32 / 2 - w / 2 ;
+        this->display->rectangle(l, 2, w, 4, this->rainbow_color); 
+        this->boot_anim++;
+      }
     }
   }
 

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -1330,6 +1330,7 @@ namespace esphome
     }
     else
     {
+      #ifdef USE_ESP32
       #ifdef EHMTXv2_ADV_BOOT
       if (this->boot_logo != NULL)
       {
@@ -1367,6 +1368,7 @@ namespace esphome
         }
       }
       else
+      #endif
       #endif
       {
         uint8_t w = 2 + ((uint8_t)(32 / 16) * (this->boot_anim / 16)) % 32;

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -1333,6 +1333,7 @@ namespace esphome
       #ifdef EHMTXv2_ADV_BOOT
       if (this->boot_logo != NULL)
       {
+        /*
         if (this->boot_anim % EHMTXv2_RAINBOW_INTERVALL == 0)
         {
           for (uint8_t x = 0; x < 32; x++)
@@ -1343,6 +1344,24 @@ namespace esphome
               {
                 this->display->draw_pixel_at(x, y, this->rainbow_color);
               }
+            }
+          }
+        }
+        */
+        if (this->boot_anim % 16 == 0)
+        {
+          uint8_t w = 2 + ((uint8_t)(32 / 16) * (i / 16)) % 32;
+          uint8_t l = 16 - w / 2 ;
+          uint8_t r = 15 + w / 2 ;
+          for (uint8_t y = 0; y < 8; y++)
+          {
+            if (this->boot_logo[l + y * 32] == 1)
+            {
+              this->display->draw_pixel_at(l, y, this->rainbow_color);
+            }
+            if (this->boot_logo[r + y * 32] == 1)
+            {
+              this->display->draw_pixel_at(r, y, this->rainbow_color);
             }
           }
         }

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -245,8 +245,7 @@ namespace esphome
     return (tokens.size() > 1) ? tokens[1] : (tokens.size() > 0) ? (iconname.find("*") != std::string::npos) ? get_icon_name(tokens[0], '_') : tokens[0] : "";
   }
 
-#ifndef USE_ESP8266
-
+#ifdef USE_ESP32
   #ifdef EHMTXv2_ADV_BOOT
   void EHMTX::set_boot_logo(std::string logo)
   {
@@ -279,6 +278,9 @@ namespace esphome
     }
   }
   #endif
+#endif
+
+#ifndef USE_ESP8266
 
   void EHMTX::bitmap_screen(std::string text, int lifetime, int screen_time)
   {
@@ -1332,9 +1334,10 @@ namespace esphome
     {
       #ifdef USE_ESP32
       #ifdef EHMTXv2_ADV_BOOT
+
       if (this->boot_logo != NULL)
       {
-        /*
+        #if defined EHMTXv2_ADV_BOOT_MODE_0 || defined EHMTXv2_ADV_BOOT_MODE_2
         if (this->boot_anim % EHMTXv2_RAINBOW_INTERVALL == 0)
         {
           for (uint8_t x = 0; x < 32; x++)
@@ -1343,12 +1346,17 @@ namespace esphome
             {
               if (this->boot_logo[x + y * 32] == 1)
               {
+                #ifdef EHMTXv2_ADV_BOOT_MODE_0
+                this->display->draw_pixel_at(x, y, Color(C_RED, C_GREEN, C_BLUE));
+                #else
                 this->display->draw_pixel_at(x, y, this->rainbow_color);
+                #endif
               }
             }
           }
         }
-        */
+        #endif
+        #if defined EHMTXv2_ADV_BOOT_MODE_1 || defined EHMTXv2_ADV_BOOT_MODE_3
         if (this->boot_anim % 8 == 0)
         {
           uint8_t w = 2 + ((uint8_t)(32 / 16) * (this->boot_anim * 2 / 16)) % 32;
@@ -1358,14 +1366,23 @@ namespace esphome
           {
             if (this->boot_logo[l + y * 32] == 1)
             {
+              #ifdef EHMTXv2_ADV_BOOT_MODE_1
+              this->display->draw_pixel_at(l, y, Color(C_RED, C_GREEN, C_BLUE));
+              #else
               this->display->draw_pixel_at(l, y, this->rainbow_color);
+              #endif
             }
             if (this->boot_logo[r + y * 32] == 1)
             {
+              #ifdef EHMTXv2_ADV_BOOT_MODE_1
+              this->display->draw_pixel_at(r, y, Color(C_RED, C_GREEN, C_BLUE));
+              #else
               this->display->draw_pixel_at(r, y, this->rainbow_color);
+              #endif
             }
           }
         }
+        #endif
       }
       else
       #endif

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -203,7 +203,7 @@ namespace esphome
       return false;
     }
   }
-
+  
   std::string get_icon_name(std::string iconname, char delim = '|')
   {
     std::stringstream stream(iconname);
@@ -239,6 +239,40 @@ namespace esphome
   }
 
 #ifndef USE_ESP8266
+
+  #ifdef EHMTXv2_ADV_BOOT
+  void set_boot_logo(std::string logo = "")
+  {
+    if (logo == "")
+    {
+      delete [] this->boot_logo;
+      this->boot_logo = nullptr;      
+      return;
+    }
+    
+    if (this->boot_logo == NULL) 
+    {
+      this->boot_logo = new uint8_t[256];
+    }
+
+    const size_t CAPACITY = JSON_ARRAY_SIZE(256);
+    StaticJsonDocument<CAPACITY> doc;
+    deserializeJson(doc, logo);
+    JsonArray array = doc.as<JsonArray>();
+    // extract the values
+    uint16_t i = 0;
+    for (JsonVariant v : array)
+    {
+      uint16_t buf = v.as<int>();
+
+      unsigned char b = (((buf)&0x001F) << 3);
+      unsigned char g = (((buf)&0x07E0) >> 3); // Fixed: shift >> 5 and << 2
+      unsigned char r = (((buf)&0xF800) >> 8); // shift >> 11 and << 3
+      this->boot_logo[i++] = (r + g + b == C_BLACK) ? 0 : 1;
+    }
+  }
+  #endif
+
   void EHMTX::bitmap_screen(std::string text, int lifetime, int screen_time)
   {
     std::string ic = get_icon_name(text);

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -241,7 +241,7 @@ namespace esphome
 #ifndef USE_ESP8266
 
   #ifdef EHMTXv2_ADV_BOOT
-  void set_boot_logo(std::string logo = "")
+  void EHMTX::set_boot_logo(std::string logo)
   {
     if (logo == "")
     {
@@ -1324,15 +1324,21 @@ namespace esphome
     else
     {
       #ifdef EHMTXv2_ADV_BOOT
-      if (this->boot_logo != NULL) 
+      if (this->boot_logo != NULL)
       {
-        for (uint8_t x = 0; x < 32; x++)
+        if (this->boot_anim % 10 == 0)
         {
-          for (uint8_t y = 0; y < 8; y++)
+          for (uint8_t x = 0; x < 32; x++)
           {
-            this->display->draw_pixel_at(x, y, this->rainbow_color);
+            for (uint8_t y = 0; y < 8; y++)
+            {
+              if (this->boot_logo[x + y * 32] == 1)
+              {
+                this->display->draw_pixel_at(x, y, this->rainbow_color);
+              }
+            }
           }
-        }        
+        }
       }
       else
       #endif
@@ -1340,8 +1346,8 @@ namespace esphome
         uint8_t w = 2 + ((uint8_t)(32 / 16) * (this->boot_anim / 16)) % 32;
         uint8_t l = 32 / 2 - w / 2 ;
         this->display->rectangle(l, 2, w, 4, this->rainbow_color); 
-        this->boot_anim++;
       }
+      this->boot_anim++;
     }
   }
 

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -1349,9 +1349,9 @@ namespace esphome
           }
         }
         */
-        if (this->boot_anim % 16 == 0)
+        if (this->boot_anim % 8 == 0)
         {
-          uint8_t w = 2 + ((uint8_t)(32 / 16) * (i / 16)) % 32;
+          uint8_t w = 2 + ((uint8_t)(32 / 16) * (this->boot_anim * 2 / 16)) % 32;
           uint8_t l = 16 - w / 2 ;
           uint8_t r = 15 + w / 2 ;
           for (uint8_t y = 0; y < 8; y++)

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -1338,20 +1338,17 @@ namespace esphome
       if (this->boot_logo != NULL)
       {
         #if defined EHMTXv2_ADV_BOOT_MODE_0 || defined EHMTXv2_ADV_BOOT_MODE_2
-        if (this->boot_anim % EHMTXv2_RAINBOW_INTERVALL == 0)
+        for (uint8_t x = 0; x < 32; x++)
         {
-          for (uint8_t x = 0; x < 32; x++)
+          for (uint8_t y = 0; y < 8; y++)
           {
-            for (uint8_t y = 0; y < 8; y++)
+            if (this->boot_logo[x + y * 32] == 1)
             {
-              if (this->boot_logo[x + y * 32] == 1)
-              {
-                #ifdef EHMTXv2_ADV_BOOT_MODE_0
-                this->display->draw_pixel_at(x, y, Color(C_RED, C_GREEN, C_BLUE));
-                #else
-                this->display->draw_pixel_at(x, y, this->rainbow_color);
-                #endif
-              }
+              #ifdef EHMTXv2_ADV_BOOT_MODE_0
+              this->display->draw_pixel_at(x, y, Color(C_RED, C_GREEN, C_BLUE));
+              #else
+              this->display->draw_pixel_at(x, y, this->rainbow_color);
+              #endif
             }
           }
         }

--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -128,6 +128,9 @@ namespace esphome
   #ifdef EHMTXv2_ADV_CLOCK
     PROGMEM Color hour_color, minutes_color, spacer_color, info_clock_lcolor, info_clock_rcolor;
   #endif
+  #ifdef EHMTXv2_ADV_BOOT
+    uint8_t* boot_logo;
+  #endif
 #endif
 
 #ifdef USE_ESP8266
@@ -212,6 +215,10 @@ namespace esphome
     #endif
     void set_default_font(display::BaseFont *font);
     void set_special_font(display::BaseFont *font);
+
+    #ifdef EHMTXv2_ADV_BOOT
+    void set_boot_logo(std::string logo = "");
+    #endif
 
     void show_rindicator(int r = C_RED, int g = C_GREEN, int b = C_BLUE, int s = 3);
     void show_lindicator(int r = C_RED, int g = C_GREEN, int b = C_BLUE, int s = 3);

--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -216,9 +216,11 @@ namespace esphome
     void set_default_font(display::BaseFont *font);
     void set_special_font(display::BaseFont *font);
 
+  #ifdef USE_ESP32
     #ifdef EHMTXv2_ADV_BOOT
-    void set_boot_logo(std::string logo = "");
+      void set_boot_logo(std::string logo = "");
     #endif
+  #endif
 
     void show_rindicator(int r = C_RED, int g = C_GREEN, int b = C_BLUE, int s = 3);
     void show_lindicator(int r = C_RED, int g = C_GREEN, int b = C_BLUE, int s = 3);

--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -492,12 +492,12 @@ namespace esphome
             this->config_->display->line(8, this->ypos(), 8, this->ypos() + 7, esphome::display::COLOR_OFF);
             if (this->icon == SOLIDICON)
             {
-              this->config_->display->filled_rectangle(0, this->ypos(), 8, 8, this->config_->solid_color); 
+              this->config_->display->filled_rectangle(0, this->ypos(), 8, 8, this->config_->solid_color);
             }
             else if (this->icon == CALENDARICON)
             {
-              this->config_->display->filled_rectangle(0, this->ypos(), 8, 8, Color(C_RED, C_GREEN, C_BLUE)); 
-              this->config_->display->filled_rectangle(0, this->ypos(), 8, 2, this->config_->calendar_color); 
+              this->config_->display->filled_rectangle(0, this->ypos(), 8, 8, Color(C_RED, C_GREEN, C_BLUE));
+              this->config_->display->filled_rectangle(0, this->ypos(), 8, 2, this->config_->calendar_color);
             }
             else
             {

--- a/components/ehmtxv2/__init__.py
+++ b/components/ehmtxv2/__init__.py
@@ -100,6 +100,7 @@ CONF_CLOCK = "advanced_clock"
 CONF_BITMAP = "advanced_bitmap"
 CONF_BOOT = "advanced_boot"
 CONF_BOOTLOGO = "boot_logo"
+CONF_BOOTMODE = "boot_mode"
 CONF_FRAMEDURATION = "frame_duration"
 CONF_SCROLLCOUNT = "scroll_count"
 CONF_MATRIXCOMPONENT = "matrix_component"
@@ -175,6 +176,9 @@ EHMTX_SCHEMA = cv.Schema({
         CONF_BOOT, default=False
     ): cv.boolean,
     cv.Optional(CONF_BOOTLOGO): cv.string,
+    cv.Optional(
+        CONF_BOOTMODE, default="2"
+    ): cv.templatable(cv.int_range(min=0, max=3)),
     cv.Optional(
         CONF_SHOW_SECONDS, default=False
     ): cv.boolean,
@@ -592,6 +596,14 @@ async def to_code(config):
     if config[CONF_BOOT] and config.get(CONF_BOOTLOGO):
         cg.add_define("EHMTXv2_ADV_BOOT")
         cg.add(var.set_boot_logo(config[CONF_BOOTLOGO]))
+        if config[CONF_BOOTMODE] == 0:
+            cg.add_define("EHMTXv2_ADV_BOOT_MODE_0")
+        if config[CONF_BOOTMODE] == 1:
+            cg.add_define("EHMTXv2_ADV_BOOT_MODE_1")
+        if config[CONF_BOOTMODE] == 2:
+            cg.add_define("EHMTXv2_ADV_BOOT_MODE_2")
+        if config[CONF_BOOTMODE] == 3:
+            cg.add_define("EHMTXv2_ADV_BOOT_MODE_3")
 
     if config[CONF_NIGHT_MODE_SCREENS]:
         cg.add_define("EHMTXv2_CONF_NIGHT_MODE_SCREENS",config[CONF_NIGHT_MODE_SCREENS])

--- a/components/ehmtxv2/__init__.py
+++ b/components/ehmtxv2/__init__.py
@@ -98,6 +98,8 @@ CONF_RTL = "rtl"
 CONF_VERTICAL = "vertical_scroll"
 CONF_CLOCK = "advanced_clock"
 CONF_BITMAP = "advanced_bitmap"
+CONF_BOOT = "advanced_boot"
+CONF_BOOTLOGO = "boot_logo"
 CONF_FRAMEDURATION = "frame_duration"
 CONF_SCROLLCOUNT = "scroll_count"
 CONF_MATRIXCOMPONENT = "matrix_component"
@@ -169,6 +171,10 @@ EHMTX_SCHEMA = cv.Schema({
     cv.Optional(
         CONF_BITMAP, default=False
     ): cv.boolean,
+    cv.Optional(
+        CONF_BOOT, default=False
+    ): cv.boolean,
+    cv.Optional(CONF_BOOTLOGO): cv.string,
     cv.Optional(
         CONF_SHOW_SECONDS, default=False
     ): cv.boolean,
@@ -572,16 +578,20 @@ async def to_code(config):
         cg.add_define("EHMTXv2_BLEND_STEPS",config[CONF_BLENDSTEPS])
 
     if config[CONF_RTL]:
-        cg.add_define("EHMTXv2_USE_RTL")    
+        cg.add_define("EHMTXv2_USE_RTL")
     
     if config[CONF_VERTICAL]:
-        cg.add_define("EHMTXv2_USE_VERTICAL_SCROLL")    
+        cg.add_define("EHMTXv2_USE_VERTICAL_SCROLL")
     
     if config[CONF_CLOCK]:
-        cg.add_define("EHMTXv2_ADV_CLOCK")    
+        cg.add_define("EHMTXv2_ADV_CLOCK")
 
     if config[CONF_BITMAP]:
-        cg.add_define("EHMTXv2_ADV_BITMAP")    
+        cg.add_define("EHMTXv2_ADV_BITMAP")
+
+    if config[CONF_BOOT] and config.get(CONF_BOOTLOGO):
+        cg.add_define("EHMTXv2_ADV_BOOT")
+        cg.add(var.set_boot_logo(config[CONF_BOOTLOGO]))
 
     if config[CONF_NIGHT_MODE_SCREENS]:
         cg.add_define("EHMTXv2_CONF_NIGHT_MODE_SCREENS",config[CONF_NIGHT_MODE_SCREENS])

--- a/components/ehmtxv2/__init__.py
+++ b/components/ehmtxv2/__init__.py
@@ -283,10 +283,10 @@ EHMTX_SCHEMA = cv.Schema({
         }
     ),
     cv.Optional(CONF_NIGHT_MODE_SCREENS, default=DEFAULT_NIGHT_MODE_SCREENS): cv.All(
-            cv.ensure_list(cv.one_of(1, 2, 3, 4, 5, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25)), cv.Length(min=1, max=5)
+            cv.ensure_list(cv.one_of(1, 2, 3, 4, 5, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26)), cv.Length(min=1, max=5)
         ),
     cv.Optional(CONF_ICON_INDICATOR_SCREENS, default=DEFAULT_ICON_INDICATOR_SCREENS): cv.All(
-            cv.ensure_list(cv.one_of(1, 2, 3, 4, 5, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25)), cv.Length(min=1, max=5)
+            cv.ensure_list(cv.one_of(1, 2, 3, 4, 5, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26)), cv.Length(min=1, max=5)
         ),
     cv.Required(CONF_ICONS): cv.All(
         cv.ensure_list(


### PR DESCRIPTION
**Advanced mode of boot logo display**

Allows you to show a custom boot logo instead of the default animation when booting.
`advanced_boot` (optional, boolean, only on ESP32, Default: false) Enables advanced mode of boot logo display.
`boot_logo` (optional, string, only on ESP32): Mask defined as rgb565 array used to display boot logo, color is completely ignored, output depends on boot logo display mode.
`boot_mode` (optional, integer, only on ESP32, Default: 3) Mode of displaying boot logo, can take value from 0 to 3:
- 0 - Display boot_logo in white color
- 1 - Display boot_logo in white color, the mask appears from the center to the sides.
- 2 - Display boot_logo with rainbow color
- 3 - Display boot_logo in rainbow color, the mask appears from the center to the sides
Mode 3 is best used with the option
```
display:
    auto_clear_enabled: false
```

After startup, to save memory, you can clear the array with the boot logo by calling the boot_logo setup function with an empty parameter.
```
id(rgb8x32)->set_boot_logo("");
```
But in case time is lost (unsynchronization), the standard animation will be shown.


**PS:** I see the readme is constantly being updated, so I decided not to add this text to the file itself. I will leave the text of changes here.