### PR TITLE
Revert "2024.1.0: Advanced clock - draw date"

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,6 @@ You can call this from, e.g., the developer tools service. [![Open your Home Ass
   fire_screen {"lifetime", "screen_time"}
 
   set_clock_infotext_color {"left_r", "left_g", "left_b", "right_r", "right_g", "right_b", "default_font", "y_offset"}
-  set_date_infotext_color {"left_r", "left_g", "left_b", "right_r", "right_g", "right_b", "default_font", "y_offset"}
   set_adv_clock_color {"hr", "hg", "hb", "mr", "mg", "mb", "sr", "sg", "sb"}
 
   text_screen_progress {"text", "value", "progress", "lifetime", "screen_time", "default_font", "value_color_as_progress", "r", "g", "b"}
@@ -870,8 +869,6 @@ ehmtxv2:
 
 **date_format** (optional, string): formats the date display with [strftime syntax](https://esphome.io/components/time.html?highlight=strftime), defaults `"%d.%m."` (use `"%m.%d."` for the US)
 
-**date_format_big** (optional, string): formats the date display with [strftime syntax](https://esphome.io/components/time.html?highlight=strftime), defaults `"%d.%m."` (use `"%m.%d."` for the US), works only in **advanced_clock** mode and sets the time format for a screen with a date without an icon
-
 **show_seconds** (optional, boolean): toggle/blink an indicator-pixel each seconds while the clock is displayed (default: false)
 
 **time_format** (optional, string): formats the date display with [strftime syntax](https://esphome.io/components/time.html?highlight=strftime), defaults `"%H:%M"` (use `"%I:%M%p"` for the US)
@@ -1056,7 +1053,6 @@ Numerous features are accessible with services from home assistant and lambdas t
 |`icon_prognosis_screen_rgb`|"icon_name", "text", "prognosis", "lifetime", "screen_time", "default_font", "r", "g", "b"|show an icon, text, and a prognosis bar consisting of 24 dots of specified colors|
 |`set_adv_clock_color`|"hr", "hg", "hb", "mr", "mg", "mb", "sr", "sg", "sb"|available only in **advanced clock mode** `advanced_clock: true`, allows you to set the color for the Hours (hr, hg, hb), Minutes (mr, mg, mb) and Spacer (sr, sg, sb), color is set by analogy with `r,g,b`. If the color is set as `black`, the standard color is used (see `set_clock_color`).|
 |`set_clock_infotext_color`|"left_r", "left_g", "left_b", "right_r", "right_g", "right_b","default_font","y_offset"|set the special color for left and right char on info text on `icon clock` screen, work only in **advanced clock mode**|
-|`set_date_infotext_color`|"left_r", "left_g", "left_b", "right_r", "right_g", "right_b","default_font","y_offset"|set the special color for left and right char on info text on `icon date` screen, work only in **advanced clock mode**|
 |`show_icon_indicator`|"r", "g", "b", "size", "pos", "height"|shows the line indicator in the Icons area on the specified screens, in the specified color and at the specified vertical position|
 |`hide_icon_indicator`|none|hides the icon indicator|
 |`expand_icon_to_9`|"mode"|Extends the icon display on the clock screen and date screen by one line (9 pixels wide). Mode 0 (default) - do not expand. Mode 1 - expand only on the clock screen. Mode 2 - expand only on the date screen. Mode 3 - expand on the screen with clock and on the screen with date. [More info](https://github.com/lubeda/EspHoMaTriXv2/pull/179)|

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -827,7 +827,6 @@ namespace esphome
 
 #ifdef EHMTXv2_ADV_CLOCK
     register_service(&EHMTX::set_clock_infotext_color, "set_clock_infotext_color", {"left_r", "left_g", "left_b", "right_r", "right_g", "right_b", "default_font", "y_offset"});
-    register_service(&EHMTX::set_date_infotext_color, "set_date_infotext_color", {"left_r", "left_g", "left_b", "right_r", "right_g", "right_b", "default_font", "y_offset"});
     register_service(&EHMTX::set_adv_clock_color, "set_adv_clock_color", {"hr", "hg", "hb", "mr", "mg", "mb", "sr", "sg", "sb"});
 #endif
 
@@ -891,10 +890,6 @@ namespace esphome
     this->info_font = df;
     this->info_y_offset = y_offset;
     ESP_LOGD(TAG, "info text color left: r: %d g: %d b: %d right: r: %d g: %d b: %d y_offset %d", lr, lg, lb, rr, rg, rb, y_offset);
-#ifdef EHMTXv2_ADV_CLOCK
-    this->set_clock_infotext_color(lr, lg, lb, rr, rg, rb, df, y_offset);
-    this->set_date_infotext_color(lr, lg, lb, rr, rg, rb, df, y_offset);
-#endif
   }
 
   void EHMTX::set_solid_color(int r, int g, int b)
@@ -2470,15 +2465,6 @@ namespace esphome
     ESP_LOGD(TAG, "info clock text color left: r: %d g: %d b: %d right: r: %d g: %d b: %d y_offset %d", lr, lg, lb, rr, rg, rb, y_offset);
   }
 
-  void EHMTX::set_date_infotext_color(int lr, int lg, int lb, int rr, int rg, int rb, bool df, int y_offset)
-  {
-    this->info_date_lcolor = Color((uint8_t)lr, (uint8_t)lg, (uint8_t)lb);
-    this->info_date_rcolor = Color((uint8_t)rr, (uint8_t)rg, (uint8_t)rb);
-    this->info_date_font = df;
-    this->info_date_y_offset = y_offset;
-    ESP_LOGD(TAG, "info date text color left: r: %d g: %d b: %d right: r: %d g: %d b: %d y_offset %d", lr, lg, lb, rr, rg, rb, y_offset);
-  }
-
   void EHMTX::set_adv_clock_color(int hr, int hg, int hb, int mr, int mg, int mb, int sr, int sg, int sb)
   {
     this->hour_color = Color((uint8_t)hr, (uint8_t)hg, (uint8_t)hb);
@@ -2508,7 +2494,7 @@ namespace esphome
       {
         if (output.find("%") != std::string::npos)
         {
-          if (this->replace_time_date_active && output == "%p") // check for replace active
+          if (output == "%p" && this->replace_time_date_active) // check for replace active
           {
             output = this->clock->now().strftime(output);
             output = this->replace_time_date(output);
@@ -2546,67 +2532,6 @@ namespace esphome
 
           this->display->printf(x, ypos, font, c_, display::TextAlign::BASELINE_LEFT, "%s", parts.at(i).c_str());
         }
-        x += len.at(i);
-      }
-    }
-
-    return true;
-  }
-
-  bool EHMTX::draw_date(std::string format, esphome::display::BaseFont *font, Color color, int xpos, int ypos)
-  {
-    std::regex rgx{"^(%\\D)(.+)(%\\D)(.+)?(?:(%\\D)(.+)?)?$"};
-    std::smatch match;
-    if (!std::regex_search(format, match, rgx))
-      return false;
-
-    std::vector<std::string> parts;
-    std::vector<uint8_t> len;
-    std::string sep = "";
-
-    uint8_t full_length = 0;
-
-    for (int i = 1; i < match.length(); i++)
-    {
-      std::string output = match[i].str();
-
-      if (output.length() > 0)
-      {
-        if (output.find("%") != std::string::npos)
-        {
-          if (this->replace_time_date_active && (output == "%a" || output == "%A" || output == "%b" || output == "%B")) // check for replace active
-          {
-            output = this->clock->now().strftime(output);
-            output = this->replace_time_date(output);
-          }
-          else
-          {
-            output = this->clock->now().strftime(output);
-          }
-        }
-        else if (sep == "")
-        {
-          sep = output;
-        }
-
-        parts.push_back(output);
-        len.push_back(output.length() > 0 ? this->GetTextWidth(font, "%s", output.c_str()) : 0);
-        full_length += len.back();
-      }
-    }
-
-    uint8_t x = xpos - full_length / 2;
-    for (int i = 0; i < parts.size(); i++)
-    {
-      if (parts.at(i).length() > 0)
-      {
-        Color c_ = parts.at(i) == sep ? this->spacer_color : color;
-        if (c_.r + c_.g + c_.b == C_BLACK)
-        {
-          c_ = color;
-        }
-        this->display->printf(x, ypos, font, c_, display::TextAlign::BASELINE_LEFT, "%s", parts.at(i).c_str());
-
         x += len.at(i);
       }
     }

--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -117,8 +117,6 @@ namespace esphome
   #ifdef EHMTXv2_ADV_CLOCK
     bool info_clock_font = true;
     int8_t info_clock_y_offset = 0;
-    bool info_date_font = true;
-    int8_t info_date_y_offset = 0;
   #endif
 #ifdef USE_ESP32
     PROGMEM Color text_color, alarm_color, rindicator_color, lindicator_color, today_color, weekday_color, rainbow_color, clock_color, info_lcolor, info_rcolor, icon_indicator_color, solid_color, calendar_color;
@@ -128,7 +126,7 @@ namespace esphome
     PROGMEM Color cgauge[8];
     PROGMEM EHMTX_Icon *icons[MAXICONS];
   #ifdef EHMTXv2_ADV_CLOCK
-    PROGMEM Color hour_color, minutes_color, spacer_color, info_clock_lcolor, info_clock_rcolor, info_date_lcolor, info_date_rcolor;
+    PROGMEM Color hour_color, minutes_color, spacer_color, info_clock_lcolor, info_clock_rcolor;
   #endif
   #ifdef EHMTXv2_ADV_BOOT
   #if defined EHMTXv2_ADV_BOOT_MODE_0 || defined EHMTXv2_ADV_BOOT_MODE_1
@@ -144,7 +142,7 @@ namespace esphome
     EHMTX_Icon *icons[MAXICONS];
     uint8_t gauge_value;
   #ifdef EHMTXv2_ADV_CLOCK
-    Color hour_color, minutes_color, spacer_color, info_clock_lcolor, info_clock_rcolor, info_date_lcolor, info_date_rcolor;
+    Color hour_color, minutes_color, spacer_color, info_clock_lcolor, info_clock_rcolor;
   #endif
 #endif
     display::BaseFont *default_font;
@@ -240,10 +238,8 @@ namespace esphome
     void set_calendar_color(int r = C_RED, int g = C_BLACK, int b = C_BLACK);
     #ifdef EHMTXv2_ADV_CLOCK
       void set_clock_infotext_color(int lr = CG_GREY, int lg = CG_GREY, int lb = CG_GREY, int rr = CG_GREY, int rg = CG_GREY, int rb = CG_GREY, bool info_font = true, int y_offset = 0);
-      void set_date_infotext_color(int lr = CG_GREY, int lg = CG_GREY, int lb = CG_GREY, int rr = CG_GREY, int rg = CG_GREY, int rb = CG_GREY, bool info_font = true, int y_offset = 0);
       void set_adv_clock_color(int hr = C_BLACK, int hg = C_BLACK, int hb = C_BLACK, int mr = C_BLACK, int mg = C_BLACK, int mb = C_BLACK, int sr = C_BLACK, int sg = C_BLACK, int sb = C_BLACK);
       bool draw_clock(std::string format, esphome::display::BaseFont *font, Color color, int xpos = 0, int ypos = 0);
-      bool draw_date(std::string format, esphome::display::BaseFont *font, Color color, int xpos = 0, int ypos = 0);
     #endif
 
     void show_alarm(int r = CA_RED, int g = CA_GREEN, int b = CA_BLUE, int s = 2);

--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -592,28 +592,19 @@ namespace esphome
         {
           color_ = (this->mode == MODE_RAINBOW_DATE) ? this->config_->rainbow_color : this->text_color;
           time_t ts = this->config_->clock->now().timestamp;
-          #ifdef EHMTXv2_ADV_CLOCK
-          if (!this->config_->draw_date(EHMTXv2_DATE_FORMAT_BIG, font, color_, xoffset + 15, this->ypos() + yoffset))
+          if (this->config_->replace_time_date_active) // check for replace active
           {
-          #endif
-            if (this->config_->replace_time_date_active) // check for replace active
-            {
-              std::string time_new = this->config_->clock->now().strftime(EHMTXv2_DATE_FORMAT).c_str();
-              time_new = this->config_->replace_time_date(time_new);
-              this->config_->display->printf(xoffset + 15, this->ypos() + yoffset, font, color_, display::TextAlign::BASELINE_CENTER, "%s", time_new.c_str());
-            }
-            else
-            {
-              this->config_->display->strftime(xoffset + 15, this->ypos() + yoffset, font, color_, display::TextAlign::BASELINE_CENTER, EHMTXv2_DATE_FORMAT,
-                                               this->config_->clock->now());                    
-            }
-            if ((this->config_->clock->now().second % 2 == 0) && this->config_->show_seconds)
-            {
-              this->config_->display->draw_pixel_at(0, 0, color_);
-            }
-          #ifdef EHMTXv2_ADV_CLOCK
+            std::string time_new = this->config_->clock->now().strftime(EHMTXv2_DATE_FORMAT).c_str();
+            time_new = this->config_->replace_time_date(time_new);
+            this->config_->display->printf(xoffset + 15, this->ypos() + yoffset, font, color_, display::TextAlign::BASELINE_CENTER, "%s", time_new.c_str());
+          } else {
+            this->config_->display->strftime(xoffset + 15, this->ypos() + yoffset, font, color_, display::TextAlign::BASELINE_CENTER, EHMTXv2_DATE_FORMAT,
+                                             this->config_->clock->now());                    
           }
-          #endif
+          if ((this->config_->clock->now().second % 2 == 0) && this->config_->show_seconds)
+          {
+            this->config_->display->draw_pixel_at(0, 0, color_);
+          }
           if (this->mode != MODE_RAINBOW_DATE)
           {
             this->config_->draw_day_of_week(this->ypos());
@@ -660,24 +651,17 @@ namespace esphome
           }
           else
           {
-            #ifdef EHMTXv2_ADV_CLOCK
-            if (!this->config_->draw_date(EHMTXv2_DATE_FORMAT, font, color_, xoffset + offset, this->ypos() + yoffset))
+            if (this->config_->replace_time_date_active) // check for replace active
             {
-            #endif
-              if (this->config_->replace_time_date_active) // check for replace active
-              {
-                std::string time_new = this->config_->clock->now().strftime(EHMTXv2_DATE_FORMAT).c_str();
-                time_new = this->config_->replace_time_date(time_new);
-                this->config_->display->printf(xoffset + offset, this->ypos() + yoffset, font, color_, display::TextAlign::BASELINE_CENTER, "%s", time_new.c_str());
-              } 
-              else 
-              {
-                this->config_->display->strftime(xoffset + offset, this->ypos() + yoffset, font, color_, display::TextAlign::BASELINE_CENTER, EHMTXv2_DATE_FORMAT,
-                                                 this->config_->clock->now());
-              }
-            #ifdef EHMTXv2_ADV_CLOCK
+              std::string time_new = this->config_->clock->now().strftime(EHMTXv2_DATE_FORMAT).c_str();
+              time_new = this->config_->replace_time_date(time_new);
+              this->config_->display->printf(xoffset + offset, this->ypos() + yoffset, font, color_, display::TextAlign::BASELINE_CENTER, "%s", time_new.c_str());
+            } 
+            else 
+            {
+              this->config_->display->strftime(xoffset + offset, this->ypos() + yoffset, font, color_, display::TextAlign::BASELINE_CENTER, EHMTXv2_DATE_FORMAT,
+                                               this->config_->clock->now());
             }
-            #endif
           }
           if (this->icon != BLANKICON)
           {
@@ -725,23 +709,16 @@ namespace esphome
           if (this->icon_name.find("day") != std::string::npos || this->icon_name.find("weekday") != std::string::npos)
           {
             int8_t i_y_offset = this->config_->info_y_offset;
-            Color i_lcolor = this->config_->info_lcolor;
+            Color i_lcolor = this->config_->info_rcolor;
             Color i_rcolor = this->config_->info_rcolor;
 
             #ifdef EHMTXv2_ADV_CLOCK
             if (this->mode == MODE_ICON_CLOCK)
             {
               i_y_offset = this->config_->info_clock_y_offset;
-              i_lcolor = this->config_->info_clock_lcolor;
+              i_lcolor = this->config_->info_clock_rcolor;
               i_rcolor = this->config_->info_clock_rcolor;
               info_font = this->config_->info_clock_font ? this->config_->default_font : this->config_->special_font;
-            }
-            else // if (this->mode == MODE_ICON_DATE)
-            {
-              i_y_offset = this->config_->info_date_y_offset;
-              i_lcolor = this->config_->info_date_lcolor;
-              i_rcolor = this->config_->info_date_rcolor;
-              info_font = this->config_->info_date_font ? this->config_->default_font : this->config_->special_font;
             }
             #endif
 

--- a/components/ehmtxv2/__init__.py
+++ b/components/ehmtxv2/__init__.py
@@ -120,7 +120,6 @@ CONF_PINGPONG = "pingpong"
 CONF_TIME_FORMAT = "time_format"
 CONF_TIME_FORMAT_BIG = "time_format_big"
 CONF_DATE_FORMAT = "date_format"
-CONF_DATE_FORMAT_BIG = "date_format_big"
 CONF_ON_START_RUNNING = "on_start_running"
 CONF_ON_EMPTY_QUEUE = "on_empty_queue"
 CONF_ON_NEXT_SCREEN = "on_next_screen"
@@ -210,9 +209,6 @@ EHMTX_SCHEMA = cv.Schema({
     ): cv.boolean,
     cv.Optional(
         CONF_DATE_FORMAT, default="%d.%m."
-    ): cv.string,
-    cv.Optional(
-        CONF_DATE_FORMAT_BIG, default="%d.%m."
     ): cv.string,
     cv.Optional(
         CONF_DEFAULT_FONT_XOFFSET, default="1"
@@ -573,10 +569,9 @@ async def to_code(config):
     cg.add_define("EHMTXv2_DEFAULT_FONT_OFFSET_Y",config[CONF_DEFAULT_FONT_YOFFSET])
     cg.add_define("EHMTXv2_SPECIAL_FONT_OFFSET_X",config[CONF_SPECIAL_FONT_XOFFSET])
     cg.add_define("EHMTXv2_SPECIAL_FONT_OFFSET_Y",config[CONF_SPECIAL_FONT_YOFFSET])
+    cg.add_define("EHMTXv2_DATE_FORMAT",config[CONF_DATE_FORMAT])
     cg.add_define("EHMTXv2_TIME_FORMAT",config[CONF_TIME_FORMAT])
     cg.add_define("EHMTXv2_TIME_FORMAT_BIG",config[CONF_TIME_FORMAT_BIG])
-    cg.add_define("EHMTXv2_DATE_FORMAT",config[CONF_DATE_FORMAT])
-    cg.add_define("EHMTXv2_DATE_FORMAT_BIG",config[CONF_DATE_FORMAT_BIG])
     
     if config[CONF_SCROLL_SMALL_TEXT]:
         cg.add_define("EHMTXv2_SCROLL_SMALL_TEXT")


### PR DESCRIPTION
Reverts lubeda/EspHoMaTriXv2#197

Your sample does not work!

```
Compiling .pioenvs/m5mic/src/main.cpp.o
<unicode string>: In lambda function:
<unicode string>:173:16: error: 'class esphome::EHMTX' has no member named 'set_clock_infotext_color'; did you mean 'set_infotext_color'?
<unicode string>:174:16: error: 'class esphome::EHMTX' has no member named 'set_adv_clock_color'; did you mean 'set_clock_color'?
<unicode string>:177:16: error: 'class esphome::EHMTX' has no member named 'set_date_infotext_color'; did you mean 'set_infotext_color'?
*** [.pioenvs/m5mic/src/main.cpp.o] Error 1
```