### PR TITLE
2024.3.0: Add Rainbow Shimmer

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,8 @@ Example:
 
 **scroll_interval** (optional, ms): the interval in ms to scroll the text (default=80), should be a multiple of the `update_interval` of [display](https://esphome.io/components/display/addressable_light.html)
 
+**rainbow_shimmer** (optional, boolean): If true, enables color shimmer when displaying text in rainbow modes.
+
 **icons2html** (optional, boolean): If true, generate the HTML-file (*filename*.html) to show all included icons. (default = `false`)
 
 **iconscache** (optional, boolean): If true, it caches icons in the `.cache\icons` folder and if it finds the specified icons in the cache, it uses them instead of trying to download them again from the Internet. (default = `false`)

--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -28,7 +28,7 @@ const uint8_t TEXTSCROLLSTART = 8;
 const uint8_t TEXTSTARTOFFSET = (32 - 8);
 
 const uint16_t POLLINGINTERVAL = 250;
-static const char *const EHMTX_VERSION = "2024.1.1";
+static const char *const EHMTX_VERSION = "2024.3.0";
 static const char *const TAG = "EHMTXv2";
 
 enum show_mode : uint8_t
@@ -107,7 +107,7 @@ namespace esphome
 #ifdef USE_Fireplugin
     void fire_screen( int lifetime, int screen_time);
 #endif    
-    uint16_t hue_ = 0;
+    uint8_t hue_ = 0;
     void dump_config();
     bool info_font = true;
     int8_t info_y_offset = 0;
@@ -292,12 +292,20 @@ namespace esphome
     void draw_lindicator();
     void draw_icon_indicator();
 
+    #ifdef EHMTXv2_RAINBOW_SHIMMER
+      void draw_rainbow_text(std::string text, esphome::display::BaseFont *font, int xpos, int ypos);
+    #endif
+
     void set_replace_time_date_active(bool b=false);
     void set_weekday_char_count(uint8_t i);
     bool replace_time_date_active;
     std::string replace_time_date(std::string time_date);
     uint8_t weekday_char_count;
     std::string GetWeekdayChar(int position);
+    std::string GetTextChar(std::string text, int position);
+    #ifdef EHMTXv2_RAINBOW_SHIMMER
+      int GetTextCharCount(std::string text);
+    #endif
 
     int GetTextBounds(esphome::display::BaseFont *font, const char *buffer);
     int GetTextWidth(esphome::display::BaseFont *font, const char* formatting, const char raw_char);

--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -503,6 +503,11 @@ namespace esphome
         this->config_->display->print(this->xpos() + xoffset, this->ypos() + yoffset, font, color_, esphome::display::TextAlign::BASELINE_RIGHT,
                                       this->text.c_str());
 #else
+        #ifdef EHMTXv2_RAINBOW_SHIMMER
+        if (this->mode == MODE_RAINBOW_BITMAP_SMALL)
+          this->config_->draw_rainbow_text(this->text, font, this->xpos() + xoffset, this->ypos() + yoffset);
+        else
+        #endif
         this->config_->display->print(this->xpos() + xoffset, this->ypos() + yoffset, font, color_, esphome::display::TextAlign::BASELINE_LEFT,
                                       this->text.c_str());
 #endif
@@ -867,6 +872,11 @@ namespace esphome
         this->config_->display->print(this->xpos() + xoffset, this->ypos() + yoffset, font, color_, esphome::display::TextAlign::BASELINE_RIGHT,
                                       this->text.c_str());
 #else
+        #ifdef EHMTXv2_RAINBOW_SHIMMER
+        if (this->mode == MODE_RAINBOW_ICON || this->mode == MODE_RAINBOW_ALERT_SCREEN)
+          this->config_->draw_rainbow_text(this->text, font, this->xpos() + xoffset, this->ypos() + yoffset);
+        else
+        #endif
         this->config_->display->print(this->xpos() + xoffset, this->ypos() + yoffset, font, color_, esphome::display::TextAlign::BASELINE_LEFT,
                                       this->text.c_str());
 #endif
@@ -1010,6 +1020,11 @@ namespace esphome
         this->config_->display->print(this->xpos() + xoffset, this->ypos() + yoffset, font, color_, esphome::display::TextAlign::BASELINE_RIGHT,
                                       this->text.c_str());
 #else
+        #ifdef EHMTXv2_RAINBOW_SHIMMER
+        if (this->mode == MODE_RAINBOW_ICON_TEXT_SCREEN)
+          this->config_->draw_rainbow_text(this->text, font, this->xpos() + xoffset, this->ypos() + yoffset);
+        else
+        #endif
         this->config_->display->print(this->xpos() + xoffset, this->ypos() + yoffset, font, color_, esphome::display::TextAlign::BASELINE_LEFT,
                                       this->text.c_str());
 #endif
@@ -1054,6 +1069,11 @@ namespace esphome
         this->config_->display->print(this->xpos() + xoffset, this->ypos() + yoffset, font, color_, esphome::display::TextAlign::BASELINE_RIGHT,
                                       this->text.c_str());
 #else
+        #ifdef EHMTXv2_RAINBOW_SHIMMER
+        if (this->mode == MODE_RAINBOW_TEXT)
+          this->config_->draw_rainbow_text(this->text, font, this->xpos() + xoffset, this->ypos() + yoffset);
+        else
+        #endif
         this->config_->display->print(this->xpos() + xoffset, this->ypos() + yoffset, font, color_, esphome::display::TextAlign::BASELINE_LEFT,
                                       this->text.c_str());
 #endif

--- a/components/ehmtxv2/__init__.py
+++ b/components/ehmtxv2/__init__.py
@@ -31,7 +31,7 @@ SVG_FULL_SCREEN_START = '<svg width="320px" height="80px" viewBox="0 0 320 80">'
 SVG_END = "</svg>"
 
 logging.warning(f"")
-logging.warning(f"!!!!This version (2024.1.0) has breaking changes!!!!")
+logging.warning(f"!!!!This version (2024.3.0) has breaking changes!!!!")
 logging.warning(f"Please check the documentation and wiki https://github.com/lubeda/EspHoMaTriXv2")
 logging.warning(f"This will only work with esphome >= 2023.7.0")
 logging.warning(f"")
@@ -108,6 +108,7 @@ CONF_CACHE = "iconscache"
 CONF_SCROLLINTERVAL = "scroll_interval"
 CONF_BLENDSTEPS = "blend_steps"
 CONF_RAINBOWINTERVAL = "rainbow_interval"
+CONF_RAINBOWSHIMMER = "rainbow_shimmer"
 CONF_FRAMEINTERVAL = "frame_interval"
 CONF_DEFAULT_FONT_ID = "default_font_id"
 CONF_DEFAULT_FONT = "default_font"
@@ -227,13 +228,15 @@ EHMTX_SCHEMA = cv.Schema({
         CONF_SPECIAL_FONT_YOFFSET, default="6"
     ): cv.templatable(cv.int_range(min=-32, max=32)),
     cv.Optional(CONF_SCROLLINTERVAL, default="80"
-                ): cv.templatable(cv.positive_int),
+    ): cv.templatable(cv.positive_int),
     cv.Optional(CONF_BLENDSTEPS, default="0"
-                ): cv.templatable(cv.positive_int),
+    ): cv.templatable(cv.positive_int),
     cv.Optional(CONF_RAINBOWINTERVAL, default="32"
-                ): cv.templatable(cv.positive_int),
+    ): cv.templatable(cv.positive_int),
+    cv.Optional(CONF_RAINBOWSHIMMER, default=False
+    ): cv.boolean,
     cv.Optional(CONF_SCROLLCOUNT, default="2"
-                ): cv.templatable(cv.positive_int),
+    ): cv.templatable(cv.positive_int),
     cv.Optional(
         CONF_FRAMEINTERVAL, default="192"
     ): cv.templatable(cv.positive_int),
@@ -578,6 +581,9 @@ async def to_code(config):
     cg.add_define("EHMTXv2_DATE_FORMAT",config[CONF_DATE_FORMAT])
     cg.add_define("EHMTXv2_DATE_FORMAT_BIG",config[CONF_DATE_FORMAT_BIG])
     
+    if config[CONF_RAINBOWSHIMMER]:
+        cg.add_define("EHMTXv2_RAINBOW_SHIMMER")
+
     if config[CONF_SCROLL_SMALL_TEXT]:
         cg.add_define("EHMTXv2_SCROLL_SMALL_TEXT")
 


### PR DESCRIPTION
Fix HUE Rainbow color loop
Add `rainbow_shimmer` (optional, boolean): If true, enables color shimmer when displaying text in rainbow modes.