### PR TITLE
Fix uninitialized brighntess_ variable

### DIFF
--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -80,7 +80,7 @@ namespace esphome
   {
   protected:
     float get_setup_priority() const override { return esphome::setup_priority::LATE; }
-    uint8_t brightness_;
+    uint8_t brightness_ = 0;
     uint8_t target_brightness_;
     uint32_t boot_anim = 0;
     uint8_t screen_pointer;


### PR DESCRIPTION
Fixes wired brightness issues at boot because of uninitialized brightness_ variable.
With this change the clock dimms to the yaml configured target brightness (or which was set via code).