### PR TITLE
2024.4.1: Specifying the brightness for the BITMAP screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1714,6 +1714,12 @@ ehmtxv2:
   advanced_bitmap: true
 ```
 
+It is also possible to specify the required brightness when displaying a given Bitmap screen (MODE_BITMAP_SCREEN).
+```
+icon: [....]|screen_id#    - Brightness 240 (Default)
+icon: [....]|screen_id#200 - Brightness 200
+```
+
 ### Select for Expand Icon to 9
 
 ```

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -2336,6 +2336,16 @@ namespace esphome
     }
   }
 
+#ifdef EHMTXv2_ADV_BITMAP
+  void EHMTX::set_brightness_silent(int value)
+  {
+    if (value < 256)
+    {
+      this->target_brightness_ = value;
+    }
+  }
+#endif
+
   uint8_t EHMTX::get_brightness()
   {
     return this->brightness_;

--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -208,6 +208,9 @@ namespace esphome
     void set_show_day_of_week(bool b=true);
     void set_show_seconds(bool b=false);
     void set_brightness(int b);
+    #ifdef EHMTXv2_ADV_BITMAP
+      void set_brightness_silent(int b);
+    #endif
     void set_display_on();
     void set_display_off();
     void set_night_mode_off();

--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -447,6 +447,24 @@ namespace esphome
         #ifdef EHMTXv2_ADV_BITMAP
         if (this->bitmap != NULL)
         {
+          std::size_t pos = icon_name.find("#");
+          if (pos != std::string::npos)
+          {
+            uint8_t bri;
+            std::string str_mode = icon_name.substr(pos + 1);
+            if (str_mode.length())
+            {
+              bri = static_cast<uint8_t>(std::stoi(str_mode));
+            }
+            else
+            {
+              bri = C_BLUE;
+            }
+            if (bri > this->config_->get_brightness())
+            {
+              this->config_->set_brightness_silent(bri);
+            }
+          }
         #endif
         for (uint8_t x = 0; x < 32; x++)
         {


### PR DESCRIPTION
Added the ability to specify the required brightness when displaying a given BITMAP screen. 
Works only in advanced BITMAP mode. 
```
icon: [....]|screen_id# - Brightness 240 (Default) 
icon: [....]|screen_id#200 - Brightness 200
```