### PR TITLE
2024.6.1: Add `multicolor text` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,29 @@ Example:
 
 **rainbow_shimmer** (optional, boolean): If true, enables color shimmer when displaying text in rainbow modes.
 
+**multicolor_text** (optional, boolean): If true, enables text multi color support when displaying text.
+
+Example:
+```Yaml
+ehmtxv2:
+  id: rgb8x32
+...
+  multicolor_text: true
+```
+
+```Yaml
+service: esphome.ulanzi_text_screen
+data:
+  default_font: true
+  text: "Test Test #00FF00Test #FF0000Test #0000FFTest"
+  lifetime: 2
+  screen_time: 10
+  r: 255
+  g: 255
+  b: 255
+```
+Shows text in different colors, `Test Test` in the default color `#FFFFFF` (r: 255, g:255, b: 255), followed by `Test` in green `#00FF00`, then `Test` in red `#FF0000` and finally `Test` in blue `#0000FF`.
+
 **icons2html** (optional, boolean): If true, generate the HTML-file (*filename*.html) to show all included icons. (default = `false`)
 
 **iconscache** (optional, boolean): If true, it caches icons in the `.cache\icons` folder and if it finds the specified icons in the cache, it uses them instead of trying to download them again from the Internet. (default = `false`)

--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -305,6 +305,7 @@ namespace esphome
     #ifdef EHMTXv2_RAINBOW_SHIMMER
       void draw_rainbow_text(std::string text, esphome::display::BaseFont *font, int xpos, int ypos);
     #endif
+    void draw_text(std::string text, esphome::display::BaseFont *font, Color color, int xpos, int ypos);
 
     void set_replace_time_date_active(bool b=false);
     void set_weekday_char_count(uint8_t i);

--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -1,4 +1,7 @@
 #include "esphome.h"
+#ifdef EHMTXv2_MULTICOLOR_TEXT
+#include <regex>
+#endif
 
 namespace esphome
 {
@@ -526,8 +529,7 @@ namespace esphome
           this->config_->draw_rainbow_text(this->text, font, this->xpos() + xoffset, this->ypos() + yoffset);
         else
         #endif
-        this->config_->display->print(this->xpos() + xoffset, this->ypos() + yoffset, font, color_, esphome::display::TextAlign::BASELINE_LEFT,
-                                      this->text.c_str());
+        this->config_->draw_text(this->text, font, color_, this->xpos() + xoffset, this->ypos() + yoffset);
 #endif
         if (this->sbitmap != NULL)
         {
@@ -895,8 +897,7 @@ namespace esphome
           this->config_->draw_rainbow_text(this->text, font, this->xpos() + xoffset, this->ypos() + yoffset);
         else
         #endif
-        this->config_->display->print(this->xpos() + xoffset, this->ypos() + yoffset, font, color_, esphome::display::TextAlign::BASELINE_LEFT,
-                                      this->text.c_str());
+        this->config_->draw_text(this->text, font, color_, this->xpos() + xoffset, this->ypos() + yoffset);
 #endif
         if (this->mode == MODE_ICON_PROGRESS)
         {
@@ -1043,8 +1044,7 @@ namespace esphome
           this->config_->draw_rainbow_text(this->text, font, this->xpos() + xoffset, this->ypos() + yoffset);
         else
         #endif
-        this->config_->display->print(this->xpos() + xoffset, this->ypos() + yoffset, font, color_, esphome::display::TextAlign::BASELINE_LEFT,
-                                      this->text.c_str());
+        this->config_->draw_text(this->text, font, color_, this->xpos() + xoffset, this->ypos() + yoffset);
 #endif
         if (this->icon != BLANKICON)
         {
@@ -1092,8 +1092,7 @@ namespace esphome
           this->config_->draw_rainbow_text(this->text, font, this->xpos() + xoffset, this->ypos() + yoffset);
         else
         #endif
-        this->config_->display->print(this->xpos() + xoffset, this->ypos() + yoffset, font, color_, esphome::display::TextAlign::BASELINE_LEFT,
-                                      this->text.c_str());
+        this->config_->draw_text(this->text, font, color_, this->xpos() + xoffset, this->ypos() + yoffset);
 #endif
         break;
 
@@ -1226,13 +1225,19 @@ namespace esphome
     uint8_t startx = 0;
     uint16_t max_steps = 0;
 
+    std::string text_ = text;
+    #ifdef EHMTXv2_MULTICOLOR_TEXT
+    std::regex color_re("(#[A-Fa-f0-9]{6})");
+    text_ = std::regex_replace(text, color_re, "");
+    #endif
+
     if (this->default_font)
     {
-      this->config_->display->get_text_bounds(0, 0, text.c_str(), this->config_->default_font, display::TextAlign::LEFT, &x, &y, &w, &h);
+      this->config_->display->get_text_bounds(0, 0, text_.c_str(), this->config_->default_font, display::TextAlign::LEFT, &x, &y, &w, &h);
     }
     else
     {
-      this->config_->display->get_text_bounds(0, 0, text.c_str(), this->config_->special_font, display::TextAlign::LEFT, &x, &y, &w, &h);
+      this->config_->display->get_text_bounds(0, 0, text_.c_str(), this->config_->special_font, display::TextAlign::LEFT, &x, &y, &w, &h);
     }
 
     this->pixels_ = w;
@@ -1296,7 +1301,6 @@ namespace esphome
     }
 
     this->scroll_reset = (width - startx) + this->pixels_;
-    ;
 
     ESP_LOGD(TAG, "calc_scroll_time: mode: %d text: \"%s\" pixels %d calculated: %.1f defined: %d max_steps: %d", this->mode, text.c_str(), this->pixels_, this->screen_time_ / 1000.0, screen_time, this->scroll_reset);
   }

--- a/components/ehmtxv2/__init__.py
+++ b/components/ehmtxv2/__init__.py
@@ -109,6 +109,7 @@ CONF_SCROLLINTERVAL = "scroll_interval"
 CONF_BLENDSTEPS = "blend_steps"
 CONF_RAINBOWINTERVAL = "rainbow_interval"
 CONF_RAINBOWSHIMMER = "rainbow_shimmer"
+CONF_MULTICOLOR_TEXT = "multicolor_text"
 CONF_FRAMEINTERVAL = "frame_interval"
 CONF_DEFAULT_FONT_ID = "default_font_id"
 CONF_DEFAULT_FONT = "default_font"
@@ -237,6 +238,8 @@ EHMTX_SCHEMA = cv.Schema({
     cv.Optional(CONF_RAINBOWINTERVAL, default="32"
     ): cv.templatable(cv.positive_int),
     cv.Optional(CONF_RAINBOWSHIMMER, default=False
+    ): cv.boolean,
+    cv.Optional(CONF_MULTICOLOR_TEXT, default=False
     ): cv.boolean,
     cv.Optional(CONF_SCROLLCOUNT, default="2"
     ): cv.templatable(cv.positive_int),
@@ -595,6 +598,10 @@ async def to_code(config):
     if config[CONF_RAINBOWSHIMMER]:
         cg.add_define("EHMTXv2_RAINBOW_SHIMMER")
         logging.info(f"[X] Rainbow shimmer")
+
+    if config[CONF_MULTICOLOR_TEXT]:
+        cg.add_define("EHMTXv2_MULTICOLOR_TEXT")
+        logging.info(f"[X] Multi color text")
 
     if config[CONF_SCROLL_SMALL_TEXT]:
         cg.add_define("EHMTXv2_SCROLL_SMALL_TEXT")


### PR DESCRIPTION
**multicolor_text** (optional, boolean): If true, enables text multi color support when displaying text.

Example:
```Yaml
ehmtxv2:
  id: rgb8x32
...
  multicolor_text: true
```

```Yaml
service: esphome.ulanzi_text_screen
data:
  default_font: true
  text: "Test Test #00FF00Test #FF0000Test #0000FFTest"
  lifetime: 2
  screen_time: 10
  r: 255
  g: 255
  b: 255
```
Shows text in different colors, `Test Test` in the default color `#FFFFFF` (r: 255, g:255, b: 255), followed by `Test` in green `#00FF00`, then `Test` in red `#FF0000` and finally `Test` in blue `#0000FF`.
