### PR TITLE
Replace usage of int with int32_t to built for both platforms arduino and esp-idf.

### DIFF
--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -94,7 +94,7 @@ namespace esphome
  * @param b blue
  * @param size 1-3
  */
-  void EHMTX::show_rindicator(int r, int g, int b, int size)
+  void EHMTX::show_rindicator(int32_t r, int32_t g, int32_t b, int32_t size)
   {
     if (size > 0)
     {
@@ -116,7 +116,7 @@ namespace esphome
  * @param b blue
  * @param size 1-3
  */
-  void EHMTX::show_lindicator(int r, int g, int b, int size)
+  void EHMTX::show_lindicator(int32_t r, int32_t g, int32_t b, int32_t size)
   {
     if (size > 0)
     {
@@ -140,7 +140,7 @@ namespace esphome
  * @param pos ??
  * @param height ??
  */
-  void EHMTX::show_icon_indicator(int r, int g, int b, int size, int pos, int height)
+  void EHMTX::show_icon_indicator(int32_t r, int32_t g, int32_t b, int32_t size, int32_t pos, int32_t height)
   {
     if (size > 0)
     {
@@ -270,7 +270,7 @@ namespace esphome
  * @param g 
  * @param b 
  */
-  void EHMTX::set_today_color(int r, int g, int b)
+  void EHMTX::set_today_color(int32_t r, int32_t g, int32_t b)
   {
     this->today_color = Color((uint8_t)r, (uint8_t)g, (uint8_t)b);
     ESP_LOGD(TAG, "default today color r: %d g: %d b: %d", r, g, b);
@@ -283,7 +283,7 @@ namespace esphome
  * @param g 
  * @param b 
  */
-  void EHMTX::set_weekday_color(int r, int g, int b)
+  void EHMTX::set_weekday_color(int32_t r, int32_t g, int32_t b)
   {
     this->weekday_color = Color((uint8_t)r, (uint8_t)g, (uint8_t)b);
     ESP_LOGD(TAG, "default weekday color: %d g: %d b: %d", r, g, b);
@@ -293,7 +293,7 @@ namespace esphome
  * 
  * @param mode the screen mode
  */
-  void EHMTX::expand_icon_to_9(int mode)
+  void EHMTX::expand_icon_to_9(int32_t mode)
   {
     this->icon_to_9 = mode;
     ESP_LOGD(TAG, "icon expanded to 9 mode: %d", mode);
@@ -405,7 +405,7 @@ namespace esphome
 #endif
 
 #ifndef USE_ESP8266
-  void EHMTX::bitmap_screen(std::string text, int lifetime, int screen_time)
+  void EHMTX::bitmap_screen(std::string text, int32_t lifetime, int32_t screen_time)
   {
     std::string ic = get_icon_name(text);
     std::string id = "";
@@ -477,7 +477,7 @@ namespace esphome
     screen->status();
   }
 
-  void EHMTX::bitmap_small(std::string icon, std::string text, int lifetime, int screen_time, bool default_font, int r, int g, int b)
+  void EHMTX::bitmap_small(std::string icon, std::string text, int32_t lifetime, int32_t screen_time, bool default_font, int32_t r, int32_t g, int32_t b)
   {
     std::string ic = get_icon_name(icon);
     std::string id = "";
@@ -539,7 +539,7 @@ namespace esphome
     screen->status();
   }
 
-  void EHMTX::rainbow_bitmap_small(std::string icon, std::string text, int lifetime, int screen_time, bool default_font)
+  void EHMTX::rainbow_bitmap_small(std::string icon, std::string text, int32_t lifetime, int32_t screen_time, bool default_font)
   {
     std::string ic = get_icon_name(icon);
     std::string id = "";
@@ -609,7 +609,7 @@ namespace esphome
     return s.substr(first, (last - first + 1));
   }
 
-  void EHMTX::bitmap_stack(std::string icons, int lifetime, int screen_time)
+  void EHMTX::bitmap_stack(std::string icons, int32_t lifetime, int32_t screen_time)
   {
     icons.erase(remove(icons.begin(), icons.end(), ' '), icons.end());
 
@@ -697,19 +697,19 @@ namespace esphome
 #endif
 
 #ifdef USE_ESP8266
-  void EHMTX::bitmap_screen(std::string text, int lifetime, int screen_time)
+  void EHMTX::bitmap_screen(std::string text, int32_t lifetime, int32_t screen_time)
   {
     ESP_LOGW(TAG, "bitmap_screen is not available on ESP8266");
   }
-  void EHMTX::bitmap_small(std::string i, std::string t, int l, int s, bool f, int r, int g, int b)
+  void EHMTX::bitmap_small(std::string i, std::string t, int32_t l, int32_t s, bool f, int32_t r, int32_t g, int32_t b)
   {
     ESP_LOGW(TAG, "bitmap_small is not available on ESP8266");
   }
-  void EHMTX::rainbow_bitmap_small(std::string i, std::string t, int l, int s, bool f)
+  void EHMTX::rainbow_bitmap_small(std::string i, std::string t, int32_t l, int32_t s, bool f)
   {
     ESP_LOGW(TAG, "bitmap_small_rainbow is not available on ESP8266");
   }
-  void EHMTX::bitmap_stack(std::string i, int l, int s)
+  void EHMTX::bitmap_stack(std::string i, int32_t l, int32_t s)
   {
     ESP_LOGW(TAG, "bitmap_stack is not available on ESP8266");
   }
@@ -787,7 +787,7 @@ namespace esphome
     }
   }
 
-  void EHMTX::show_gauge(int percent, int r, int g, int b, int bg_r, int bg_g, int bg_b)
+  void EHMTX::show_gauge(int32_t percent, int32_t r, int32_t g, int32_t b, int32_t bg_r, int32_t bg_g, int32_t bg_b)
   {
     if (percent <= 100)
     {
@@ -809,7 +809,7 @@ namespace esphome
     }
   }
 #else
-  void EHMTX::show_gauge(int percent, int r, int g, int b, int bg_r, int bg_g, int bg_b)
+  void EHMTX::show_gauge(int32_t percent, int32_t r, int32_t g, int32_t b, int32_t bg_r, int32_t bg_g, int32_t bg_b)
   {
     this->display_gauge = false;
     if (percent <= 100)
@@ -942,7 +942,7 @@ namespace esphome
     ESP_LOGD(TAG, "Setup and running!");
   }
 
-  void EHMTX::show_alarm(int r, int g, int b, int size)
+  void EHMTX::show_alarm(int32_t r, int32_t g, int32_t b, int32_t size)
   {
     if (size > 0)
     {
@@ -962,7 +962,7 @@ namespace esphome
     ESP_LOGD(TAG, "hide alarm");
   }
 
-  void EHMTX::set_clock_color(int r, int g, int b)
+  void EHMTX::set_clock_color(int32_t r, int32_t g, int32_t b)
   {
     this->clock_color = Color((uint8_t)r, (uint8_t)g, (uint8_t)b);
 
@@ -979,13 +979,13 @@ namespace esphome
     ESP_LOGD(TAG, "default clock color r: %d g: %d b: %d", r, g, b);
   }
 
-  void EHMTX::set_text_color(int r, int g, int b)
+  void EHMTX::set_text_color(int32_t r, int32_t g, int32_t b)
   {
     this->text_color = Color((uint8_t)r, (uint8_t)g, (uint8_t)b);
     ESP_LOGD(TAG, "default text color r: %d g: %d b: %d", r, g, b);
   }
 
-  void EHMTX::set_infotext_color(int lr, int lg, int lb, int rr, int rg, int rb, bool df, int y_offset)
+  void EHMTX::set_infotext_color(int32_t lr, int32_t lg, int32_t lb, int32_t rr, int32_t rg, int32_t rb, bool df, int32_t y_offset)
   {
     this->info_lcolor = Color((uint8_t)lr, (uint8_t)lg, (uint8_t)lb);
     this->info_rcolor = Color((uint8_t)rr, (uint8_t)rg, (uint8_t)rb);
@@ -998,13 +998,13 @@ namespace esphome
 #endif
   }
 
-  void EHMTX::set_solid_color(int r, int g, int b)
+  void EHMTX::set_solid_color(int32_t r, int32_t g, int32_t b)
   {
     this->solid_color = Color((uint8_t)r, (uint8_t)g, (uint8_t)b);
     ESP_LOGD(TAG, "solid icon color r: %d g: %d b: %d", r, g, b);
   }
 
-  void EHMTX::set_calendar_color(int r, int g, int b)
+  void EHMTX::set_calendar_color(int32_t r, int32_t g, int32_t b)
   {
     this->calendar_color = Color((uint8_t)r, (uint8_t)g, (uint8_t)b);
     ESP_LOGD(TAG, "calendar icon color r: %d g: %d b: %d", r, g, b);
@@ -1032,7 +1032,7 @@ namespace esphome
     }
   }
 
-  void EHMTX::force_screen(std::string icon_name, int mode)
+  void EHMTX::force_screen(std::string icon_name, int32_t mode)
   {
     for (uint8_t i = 0; i < MAXQUEUE; i++)
     {
@@ -1576,7 +1576,7 @@ namespace esphome
     this->next_action_time = this->get_tick() - 1000.0;
   }
 
-  void EHMTX::hold_screen(int time)
+  void EHMTX::hold_screen(int32_t time)
   {
     this->next_action_time = this->get_tick() + time * 1000.0;
   }
@@ -1681,7 +1681,7 @@ namespace esphome
     return time_date;
   }
 
-  void EHMTX::del_screen(std::string icon_name, int mode)
+  void EHMTX::del_screen(std::string icon_name, int32_t mode)
   {
     for (uint8_t i = 0; i < MAXQUEUE; i++)
     {
@@ -1747,7 +1747,7 @@ namespace esphome
     }
   }
 
-  void EHMTX::alert_screen(std::string iconname, std::string text, int screen_time, bool default_font, int r, int g, int b)
+  void EHMTX::alert_screen(std::string iconname, std::string text, int32_t screen_time, bool default_font, int32_t r, int32_t g, int32_t b)
   {
     uint8_t icon = this->find_icon(iconname.c_str());
 
@@ -1782,7 +1782,7 @@ namespace esphome
     force_screen(iconname, MODE_ALERT_SCREEN);
   }
 
-  void EHMTX::rainbow_alert_screen(std::string iconname, std::string text, int screen_time, bool default_font)
+  void EHMTX::rainbow_alert_screen(std::string iconname, std::string text, int32_t screen_time, bool default_font)
   {
     uint8_t icon = this->find_icon(iconname.c_str());
 
@@ -1816,7 +1816,7 @@ namespace esphome
     force_screen(iconname, MODE_RAINBOW_ALERT_SCREEN);
   }
 
-  void EHMTX::icon_screen(std::string iconname, std::string text, int lifetime, int screen_time, bool default_font, int r, int g, int b)
+  void EHMTX::icon_screen(std::string iconname, std::string text, int32_t lifetime, int32_t screen_time, bool default_font, int32_t r, int32_t g, int32_t b)
   {
     std::string ic = get_icon_name(iconname);
     std::string id = get_screen_id(iconname);
@@ -1850,7 +1850,7 @@ namespace esphome
     screen->status();
   }
 
-  void EHMTX::text_screen_progress(std::string text, std::string value, int progress, int lifetime, int screen_time, bool default_font, bool value_color_as_progress, int r, int g, int b)
+  void EHMTX::text_screen_progress(std::string text, std::string value, int32_t progress, int32_t lifetime, int32_t screen_time, bool default_font, bool value_color_as_progress, int32_t r, int32_t g, int32_t b)
   {
     EHMTX_queue *screen = this->find_mode_icon_queue_element(MODE_TEXT_PROGRESS, text);
 
@@ -1876,7 +1876,7 @@ namespace esphome
     screen->status();
   }
 
-  void EHMTX::icon_screen_progress(std::string iconname, std::string text, int progress, int lifetime, int screen_time, bool default_font, int r, int g, int b)
+  void EHMTX::icon_screen_progress(std::string iconname, std::string text, int32_t progress, int32_t lifetime, int32_t screen_time, bool default_font, int32_t r, int32_t g, int32_t b)
   {
     std::string ic = get_icon_name(iconname);
     std::string id = get_screen_id(iconname);
@@ -1912,7 +1912,7 @@ namespace esphome
     screen->status();
   }
 
-  void EHMTX::set_progressbar_color(std::string iconname, int mode, int r, int g, int b, int bg_r, int bg_g, int bg_b)
+  void EHMTX::set_progressbar_color(std::string iconname, int32_t mode, int32_t r, int32_t g, int32_t b, int32_t bg_r, int32_t bg_g, int32_t bg_b)
   {
     EHMTX_queue *screen = this->find_mode_icon_queue_element(mode, get_screen_id(iconname));
 
@@ -1923,7 +1923,7 @@ namespace esphome
     screen->status();
   }
 
-  void EHMTX::icon_clock(std::string iconname, int lifetime, int screen_time, bool default_font, int r, int g, int b)
+  void EHMTX::icon_clock(std::string iconname, int32_t lifetime, int32_t screen_time, bool default_font, int32_t r, int32_t g, int32_t b)
   {
     std::string ic = get_icon_name(iconname);
     std::string id = get_screen_id(iconname);
@@ -1960,7 +1960,7 @@ namespace esphome
     screen->status();
   }
 
-  void EHMTX::icon_date(std::string iconname, int lifetime, int screen_time, bool default_font, int r, int g, int b)
+  void EHMTX::icon_date(std::string iconname, int32_t lifetime, int32_t screen_time, bool default_font, int32_t r, int32_t g, int32_t b)
   {
     std::string ic = get_icon_name(iconname);
     std::string id = get_screen_id(iconname);
@@ -1997,7 +1997,7 @@ namespace esphome
     screen->status();
   }
 
-  void EHMTX::rainbow_icon_screen(std::string iconname, std::string text, int lifetime, int screen_time, bool default_font)
+  void EHMTX::rainbow_icon_screen(std::string iconname, std::string text, int32_t lifetime, int32_t screen_time, bool default_font)
   {
     std::string ic = get_icon_name(iconname);
     std::string id = get_screen_id(iconname);
@@ -2031,7 +2031,7 @@ namespace esphome
     screen->status();
   }
 
-  void EHMTX::rainbow_clock_screen(int lifetime, int screen_time, bool default_font)
+  void EHMTX::rainbow_clock_screen(int32_t lifetime, int32_t screen_time, bool default_font)
   {
     EHMTX_queue *screen = this->find_mode_queue_element(MODE_RAINBOW_CLOCK);
 
@@ -2054,7 +2054,7 @@ namespace esphome
     screen->status();
   }
 
-  void EHMTX::rainbow_date_screen(int lifetime, int screen_time, bool default_font)
+  void EHMTX::rainbow_date_screen(int32_t lifetime, int32_t screen_time, bool default_font)
   {
     ESP_LOGD(TAG, "rainbow_date_screen lifetime: %d screen_time: %d", lifetime, screen_time);
     EHMTX_queue *screen = this->find_mode_queue_element(MODE_RAINBOW_DATE);
@@ -2070,7 +2070,7 @@ namespace esphome
     screen->status();
   }
 
-  void EHMTX::blank_screen(int lifetime, int showtime)
+  void EHMTX::blank_screen(int32_t lifetime, int32_t showtime)
   {
     EHMTX_queue *screen = this->find_free_queue_element();
     screen->mode = MODE_BLANK;
@@ -2083,7 +2083,7 @@ namespace esphome
     screen->status();
   }
 
-  void EHMTX::color_screen(int lifetime, int showtime, int r, int g, int b)
+  void EHMTX::color_screen(int32_t lifetime, int32_t showtime, int32_t r, int32_t g, int32_t b)
   {
     EHMTX_queue *screen = this->find_free_queue_element();
     screen->mode = MODE_COLOR;
@@ -2097,7 +2097,7 @@ namespace esphome
     screen->status();
   }
 
-  void EHMTX::text_screen(std::string text, int lifetime, int screen_time, bool default_font, int r, int g, int b)
+  void EHMTX::text_screen(std::string text, int32_t lifetime, int32_t screen_time, bool default_font, int32_t r, int32_t g, int32_t b)
   {
     EHMTX_queue *screen = this->find_free_queue_element();
 
@@ -2110,7 +2110,7 @@ namespace esphome
     screen->status();
   }
 
-  void EHMTX::rainbow_text_screen(std::string text, int lifetime, int screen_time, bool default_font)
+  void EHMTX::rainbow_text_screen(std::string text, int32_t lifetime, int32_t screen_time, bool default_font)
   {
     EHMTX_queue *screen = this->find_free_queue_element();
     screen->text = text;
@@ -2122,7 +2122,7 @@ namespace esphome
   }
 
 #ifdef USE_Fireplugin
-  void EHMTX::fire_screen(int lifetime, int screen_time)
+  void EHMTX::fire_screen(int32_t lifetime, int32_t screen_time)
   {
     EHMTX_queue *screen = this->find_mode_queue_element(MODE_FIRE);
     screen->mode = MODE_FIRE;
@@ -2142,7 +2142,7 @@ namespace esphome
   }
 #endif
 
-  void EHMTX::full_screen(std::string iconname, int lifetime, int screen_time)
+  void EHMTX::full_screen(std::string iconname, int32_t lifetime, int32_t screen_time)
   {
     uint8_t icon = this->find_icon(iconname.c_str());
 
@@ -2174,7 +2174,7 @@ namespace esphome
     screen->status();
   }
 
-  void EHMTX::clock_screen(int lifetime, int screen_time, bool default_font, int r, int g, int b)
+  void EHMTX::clock_screen(int32_t lifetime, int32_t screen_time, bool default_font, int32_t r, int32_t g, int32_t b)
   {
     EHMTX_queue *screen = this->find_mode_queue_element(MODE_CLOCK);
     screen->text_color = Color(r, g, b);
@@ -2190,7 +2190,7 @@ namespace esphome
     screen->status();
   }
 
-  void EHMTX::date_screen(int lifetime, int screen_time, bool default_font, int r, int g, int b)
+  void EHMTX::date_screen(int32_t lifetime, int32_t screen_time, bool default_font, int32_t r, int32_t g, int32_t b)
   {
     ESP_LOGD(TAG, "date_screen lifetime: %d screen_time: %d red: %d green: %d blue: %d", lifetime, screen_time, r, g, b);
     EHMTX_queue *screen = this->find_free_queue_element();
@@ -2208,7 +2208,7 @@ namespace esphome
     screen->status();
   }
 
-  void EHMTX::icon_text_screen(std::string iconname, std::string text, int lifetime, int screen_time, bool default_font, int r, int g, int b)
+  void EHMTX::icon_text_screen(std::string iconname, std::string text, int32_t lifetime, int32_t screen_time, bool default_font, int32_t r, int32_t g, int32_t b)
   {
     std::string ic = get_icon_name(iconname);
     std::string id = get_screen_id(iconname);
@@ -2242,7 +2242,7 @@ namespace esphome
     screen->status();
   }
 
-  void EHMTX::rainbow_icon_text_screen(std::string iconname, std::string text, int lifetime, int screen_time, bool default_font)
+  void EHMTX::rainbow_icon_text_screen(std::string iconname, std::string text, int32_t lifetime, int32_t screen_time, bool default_font)
   {
     std::string ic = get_icon_name(iconname);
     std::string id = get_screen_id(iconname);
@@ -2275,12 +2275,12 @@ namespace esphome
     screen->status();
   }
 
-  void EHMTX::icon_prognosis_screen(std::string iconname, std::string text, std::string prognosis, int lifetime, int screen_time, bool default_font)
+  void EHMTX::icon_prognosis_screen(std::string iconname, std::string text, std::string prognosis, int32_t lifetime, int32_t screen_time, bool default_font)
   {
     this->icon_prognosis_screen_rgb(iconname, text, prognosis, lifetime, screen_time, default_font, C_BLACK, C_BLACK, C_BLACK);
   }
 
-  void EHMTX::icon_prognosis_screen_rgb(std::string iconname, std::string text, std::string prognosis, int lifetime, int screen_time, bool default_font, int r, int g, int b)
+  void EHMTX::icon_prognosis_screen_rgb(std::string iconname, std::string text, std::string prognosis, int32_t lifetime, int32_t screen_time, bool default_font, int32_t r, int32_t g, int32_t b)
   {
     std::string ic = get_icon_name(iconname);
     std::string id = get_screen_id(iconname);
@@ -2425,7 +2425,7 @@ namespace esphome
     ESP_LOGI(TAG, "%sshow day of week", b ? F("") : F("don't "));
   }
 
-  void EHMTX::set_brightness(int value)
+  void EHMTX::set_brightness(int32_t value)
   {
     if (value < 256)
     {
@@ -2436,7 +2436,7 @@ namespace esphome
   }
 
 #ifdef EHMTXv2_ADV_BITMAP
-  void EHMTX::set_brightness_silent(int value)
+  void EHMTX::set_brightness_silent(int32_t value)
   {
     if (value < 256)
     {
@@ -2471,7 +2471,7 @@ namespace esphome
     ESP_LOGD(TAG, "set_graph");
   }
 
-  void EHMTX::graph_screen(int lifetime, int screen_time)
+  void EHMTX::graph_screen(int32_t lifetime, int32_t screen_time)
   {
     ESP_LOGD(TAG, "graph screen: lifetime: %d screen_time: %d", lifetime, screen_time);
 
@@ -2496,7 +2496,7 @@ namespace esphome
     screen->status();
   }
 
-  void EHMTX::icon_graph_screen(std::string iconname, int lifetime, int screen_time)
+  void EHMTX::icon_graph_screen(std::string iconname, int32_t lifetime, int32_t screen_time)
   {
     uint8_t icon = this->find_icon(iconname.c_str());
 
@@ -2544,7 +2544,7 @@ namespace esphome
 
 #define max3(x, y, z) ((x) > (y) ? ((x) > (z) ? (x) : (z)) : ((y) > (z) ? (y) : (z)))
 
-  void EHMTX::draw_day_of_week(int ypos, bool small)
+  void EHMTX::draw_day_of_week(int32_t ypos, bool small)
   {
     if (this->show_day_of_week)
     {
@@ -2601,7 +2601,7 @@ namespace esphome
   }
 
 #ifdef EHMTXv2_ADV_CLOCK
-  void EHMTX::set_clock_infotext_color(int lr, int lg, int lb, int rr, int rg, int rb, bool df, int y_offset)
+  void EHMTX::set_clock_infotext_color(int32_t lr, int32_t lg, int32_t lb, int32_t rr, int32_t rg, int32_t rb, bool df, int32_t y_offset)
   {
     this->info_clock_lcolor = Color((uint8_t)lr, (uint8_t)lg, (uint8_t)lb);
     this->info_clock_rcolor = Color((uint8_t)rr, (uint8_t)rg, (uint8_t)rb);
@@ -2610,7 +2610,7 @@ namespace esphome
     ESP_LOGD(TAG, "info clock text color left: r: %d g: %d b: %d right: r: %d g: %d b: %d y_offset %d", lr, lg, lb, rr, rg, rb, y_offset);
   }
 
-  void EHMTX::set_date_infotext_color(int lr, int lg, int lb, int rr, int rg, int rb, bool df, int y_offset)
+  void EHMTX::set_date_infotext_color(int32_t lr, int32_t lg, int32_t lb, int32_t rr, int32_t rg, int32_t rb, bool df, int32_t y_offset)
   {
     this->info_date_lcolor = Color((uint8_t)lr, (uint8_t)lg, (uint8_t)lb);
     this->info_date_rcolor = Color((uint8_t)rr, (uint8_t)rg, (uint8_t)rb);
@@ -2619,7 +2619,7 @@ namespace esphome
     ESP_LOGD(TAG, "info date text color left: r: %d g: %d b: %d right: r: %d g: %d b: %d y_offset %d", lr, lg, lb, rr, rg, rb, y_offset);
   }
 
-  void EHMTX::set_adv_clock_color(int hr, int hg, int hb, int mr, int mg, int mb, int sr, int sg, int sb)
+  void EHMTX::set_adv_clock_color(int32_t hr, int32_t hg, int32_t hb, int32_t mr, int32_t mg, int32_t mb, int32_t sr, int32_t sg, int32_t sb)
   {
     this->hour_color = Color((uint8_t)hr, (uint8_t)hg, (uint8_t)hb);
     this->minutes_color = Color((uint8_t)mr, (uint8_t)mg, (uint8_t)mb);
@@ -2627,7 +2627,7 @@ namespace esphome
     ESP_LOGD(TAG, "advanced clock color hour: r: %d g: %d b: %d minutes: r: %d g: %d b: %d spacer: r: %d g: %d b: %d", hr, hg, hb, mr, mg, mb, sr, sg, sb);
   }
 
-  bool EHMTX::draw_clock(std::string format, esphome::display::BaseFont *font, Color color, int xpos, int ypos)
+  bool EHMTX::draw_clock(std::string format, esphome::display::BaseFont *font, Color color, int32_t xpos, int32_t ypos)
   {
     std::regex rgx{"^(%[HI])(.)(%M)(.)?(%S|%p)?$"};
     std::smatch match;
@@ -2651,7 +2651,7 @@ namespace esphome
 
     uint8_t full_length = 0;
 
-    for (int i = 1; i < match.length(); i++)
+    for (int32_t i = 1; i < match.length(); i++)
     {
       std::string output = match[i].str();
 
@@ -2690,8 +2690,8 @@ namespace esphome
       }
     }
 
-    int x = xpos - full_length / 2;
-    for (int i = 0; i < parts.size(); i++)
+    int32_t x = xpos - full_length / 2;
+    for (int32_t i = 0; i < parts.size(); i++)
     {
       if (parts.at(i).length() > 0)
       {
@@ -2826,7 +2826,7 @@ namespace esphome
     return true;
   }
 
-  bool EHMTX::draw_date(std::string format, esphome::display::BaseFont *font, Color color, int xpos, int ypos)
+  bool EHMTX::draw_date(std::string format, esphome::display::BaseFont *font, Color color, int32_t xpos, int32_t ypos)
   {
     std::regex rgx{"^(%\\D)(.+)(%\\D)(.+)?(?:(%\\D)(.+)?)?$"};
     std::smatch match;
@@ -2839,7 +2839,7 @@ namespace esphome
 
     uint8_t full_length = 0;
 
-    for (int i = 1; i < match.length(); i++)
+    for (int32_t i = 1; i < match.length(); i++)
     {
       std::string output = match[i].str();
 
@@ -2869,7 +2869,7 @@ namespace esphome
     }
 
     uint8_t x = xpos - full_length / 2;
-    for (int i = 0; i < parts.size(); i++)
+    for (int32_t i = 0; i < parts.size(); i++)
     {
       if (parts.at(i).length() > 0)
       {
@@ -2888,7 +2888,7 @@ namespace esphome
   }
 #endif
 
-  void EHMTX::draw_text(std::string text, esphome::display::BaseFont *font, Color color, int xpos, int ypos)
+  void EHMTX::draw_text(std::string text, esphome::display::BaseFont *font, Color color, int32_t xpos, int32_t ypos)
   {
   #ifdef EHMTXv2_MULTICOLOR_TEXT
     std::size_t pos = text.find("#");
@@ -2930,13 +2930,13 @@ namespace esphome
     }
     
     Color c = color;
-    int x = xpos;
+    int32_t x = xpos;
     std::regex is_color ("^#[A-Fa-f0-9]{6}$");
-    for (int i = 0; i < res.size(); i++)
+    for (int32_t i = 0; i < res.size(); i++)
     {
       if (res.at(i).length() > 0)
       {
-        int r, g, b;
+        int32_t r, g, b;
         if (res.at(i).length() == 7 && std::regex_match(res.at(i), is_color) && sscanf(&res.at(i).c_str()[1], "%02x%02x%02x", &r, &g, &b))
         {
           if (r + g + b > 0)
@@ -2961,7 +2961,7 @@ namespace esphome
   }
 
 #ifdef EHMTXv2_RAINBOW_SHIMMER
-  void EHMTX::draw_rainbow_text(std::string text, esphome::display::BaseFont *font, int xpos, int ypos)
+  void EHMTX::draw_rainbow_text(std::string text, esphome::display::BaseFont *font, int32_t xpos, int32_t ypos)
   {
     uint16_t str_len  = GetTextCharCount(text);
     uint16_t x        = 0;
@@ -2984,17 +2984,17 @@ namespace esphome
     this->weekday_char_count = i;
   }
 
-  std::string EHMTX::GetWeekdayChar(int position)
+  std::string EHMTX::GetWeekdayChar(int32_t position)
   {
     return GetTextChar(EHMTXv2_WEEKDAYTEXT, position);
   }
 
-  std::string EHMTX::GetTextChar(std::string text, int position)
+  std::string EHMTX::GetTextChar(std::string text, int32_t position)
   {
     std::string text_char = "";
-    int pos = 0;
+    int32_t pos = 0;
 
-    for (int i = 0; i < strlen(text.c_str());)
+    for (int32_t i = 0; i < strlen(text.c_str());)
     {
       text_char = text_char + text[i];
       if (text[i] & 0x80)
@@ -3035,11 +3035,11 @@ namespace esphome
   }
 
 #ifdef EHMTXv2_RAINBOW_SHIMMER
-  int EHMTX::GetTextCharCount(std::string text)
+  int32_t EHMTX::GetTextCharCount(std::string text)
   {
-    int count = 0;
+    int32_t count = 0;
   
-    for (int i = 0; i < strlen(text.c_str());) 
+    for (int32_t i = 0; i < strlen(text.c_str());)
     {
       if(text[i] & 0x80) 
       {
@@ -3070,7 +3070,7 @@ namespace esphome
   }
 #endif
 
-  int EHMTX::GetTextBounds(esphome::display::BaseFont *font, const char *buffer)
+  int32_t EHMTX::GetTextBounds(esphome::display::BaseFont *font, const char *buffer)
   {
     int x = 0;      // A pointer to store the returned x coordinate of the upper left corner in.
     int y = 0;      // A pointer to store the returned y coordinate of the upper left corner in.
@@ -3080,35 +3080,35 @@ namespace esphome
     return width;
   }
 
-  int EHMTX::GetTextWidth(esphome::display::BaseFont *font, const char *formatting, const char raw_char)
+  int32_t EHMTX::GetTextWidth(esphome::display::BaseFont *font, const char *formatting, const char raw_char)
   {
     char temp_buffer[80];
     sprintf(temp_buffer, formatting, raw_char);
     return GetTextBounds(font, temp_buffer);
   }
 
-  int EHMTX::GetTextWidth(esphome::display::BaseFont *font, const char *formatting, const char *raw_text)
+  int32_t EHMTX::GetTextWidth(esphome::display::BaseFont *font, const char *formatting, const char *raw_text)
   {
     char temp_buffer[80];
     sprintf(temp_buffer, formatting, raw_text);
     return GetTextBounds(font, temp_buffer);
   }
 
-  int EHMTX::GetTextWidth(esphome::display::BaseFont *font, const char *formatting, const int raw_int)
+  int32_t EHMTX::GetTextWidth(esphome::display::BaseFont *font, const char *formatting, const int32_t raw_int)
   {
     char temp_buffer[80];
     sprintf(temp_buffer, formatting, raw_int);
     return GetTextBounds(font, temp_buffer);
   }
 
-  int EHMTX::GetTextWidth(esphome::display::BaseFont *font, const char *formatting, const float raw_float)
+  int32_t EHMTX::GetTextWidth(esphome::display::BaseFont *font, const char *formatting, const float raw_float)
   {
     char temp_buffer[80];
     sprintf(temp_buffer, formatting, raw_float);
     return GetTextBounds(font, temp_buffer);
   }
 
-  int EHMTX::GetTextWidth(esphome::display::BaseFont *font, const char *formatting, esphome::ESPTime time)
+  int32_t EHMTX::GetTextWidth(esphome::display::BaseFont *font, const char *formatting, esphome::ESPTime time)
   {
     auto c_tm = time.to_c_tm();
     size_t buffer_length = 80;

--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -111,7 +111,7 @@ namespace esphome
     EHMTX();
 
 #ifdef USE_Fireplugin
-    void fire_screen( int lifetime, int screen_time);
+    void fire_screen( int32_t lifetime, int32_t screen_time);
 #endif    
     uint8_t hue_ = 0;
     void dump_config();
@@ -155,10 +155,10 @@ namespace esphome
 #endif
     display::BaseFont *default_font;
     display::BaseFont *special_font;
-    int display_rindicator;
-    int display_lindicator;
-    int display_icon_indicator;
-    int display_alarm;
+    int32_t display_rindicator;
+    int32_t display_lindicator;
+    int32_t display_icon_indicator;
+    int32_t display_alarm;
     uint8_t ticks_per_second=62;
     bool display_gauge;
     bool is_running = false;
@@ -170,8 +170,8 @@ namespace esphome
     addressable_light::AddressableLightDisplay *display;
     esphome::time::RealTimeClock *clock;
     #ifdef USE_GRAPH
-      void graph_screen(int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME);
-      void icon_graph_screen(std::string icon, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME);
+      void graph_screen(int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME);
+      void icon_graph_screen(std::string icon, int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME);
       graph::Graph *graph;
     #endif
 
@@ -192,7 +192,7 @@ namespace esphome
     uint8_t find_oldest_queue_element();
     uint8_t queue_count();
     uint8_t find_icon_in_queue(std::string);
-    void force_screen(std::string name, int mode = MODE_ICON_SCREEN);
+    void force_screen(std::string name, int32_t mode = MODE_ICON_SCREEN);
     void add_icon(EHMTX_Icon *icon);
     bool show_display = false;
     bool night_mode = false;
@@ -200,7 +200,7 @@ namespace esphome
     uint8_t find_icon(std::string name);
     uint8_t find_last_clock();
     bool string_has_ending(std::string const &fullString, std::string const &ending);
-    void draw_day_of_week(int ypos = 0, bool small = false);
+    void draw_day_of_week(int32_t ypos = 0, bool small = false);
     void show_all_icons();
     float get_tick();
     void tick();
@@ -208,14 +208,14 @@ namespace esphome
     void get_status();
     void queue_status();
     void skip_screen();
-    void hold_screen(int t = 30);
+    void hold_screen(int32_t t = 30);
     void set_display(addressable_light::AddressableLightDisplay *disp);
     void set_clock_time(uint16_t t = 10);
     void set_show_day_of_week(bool b=true);
     void set_show_seconds(bool b=false);
-    void set_brightness(int b);
+    void set_brightness(int32_t b);
     #ifdef EHMTXv2_ADV_BITMAP
-      void set_brightness_silent(int b);
+      void set_brightness_silent(int32_t b);
     #endif
     void set_display_on();
     void set_display_off();
@@ -223,7 +223,7 @@ namespace esphome
     void set_night_mode_on();
     void set_weekday_accent_off();
     void set_weekday_accent_on();
-    void expand_icon_to_9(int mode=0);
+    void expand_icon_to_9(int32_t mode=0);
     void set_clock(esphome::time::RealTimeClock *clock);
     #ifdef USE_GRAPH
       void set_graph(esphome::graph::Graph *graph);
@@ -237,63 +237,63 @@ namespace esphome
     #endif
   #endif
 
-    void show_rindicator(int r = C_RED, int g = C_GREEN, int b = C_BLUE, int s = 3);
-    void show_lindicator(int r = C_RED, int g = C_GREEN, int b = C_BLUE, int s = 3);
-    void show_icon_indicator(int r = C_RED, int g = C_GREEN, int b = C_BLUE, int s = 8, int pos = 7, int h = 1);
-    void set_text_color(int r = C_RED, int g = C_GREEN, int b = C_BLUE);
-    void set_today_color(int r = C_RED, int g = C_GREEN, int b = C_BLUE);
-    void set_weekday_color(int r = CD_RED, int g = CD_GREEN, int b = CD_BLUE);
-    void set_clock_color(int r = C_RED, int g = C_GREEN, int b = C_BLUE);
-    void set_infotext_color(int lr = CG_GREY, int lg = CG_GREY, int lb = CG_GREY, int rr = CG_GREY, int rg = CG_GREY, int rb = CG_GREY, bool info_font = true, int y_offset = 0);
-    void set_solid_color(int r = C_RED, int g = C_GREEN, int b = C_BLUE);
-    void set_calendar_color(int r = C_RED, int g = C_BLACK, int b = C_BLACK);
+    void show_rindicator(int32_t r = C_RED, int32_t g = C_GREEN, int32_t b = C_BLUE, int32_t s = 3);
+    void show_lindicator(int32_t r = C_RED, int32_t g = C_GREEN, int32_t b = C_BLUE, int32_t s = 3);
+    void show_icon_indicator(int32_t r = C_RED, int32_t g = C_GREEN, int32_t b = C_BLUE, int32_t s = 8, int32_t pos = 7, int32_t h = 1);
+    void set_text_color(int32_t r = C_RED, int32_t g = C_GREEN, int32_t b = C_BLUE);
+    void set_today_color(int32_t r = C_RED, int32_t g = C_GREEN, int32_t b = C_BLUE);
+    void set_weekday_color(int32_t r = CD_RED, int32_t g = CD_GREEN, int32_t b = CD_BLUE);
+    void set_clock_color(int32_t r = C_RED, int32_t g = C_GREEN, int32_t b = C_BLUE);
+    void set_infotext_color(int32_t lr = CG_GREY, int32_t lg = CG_GREY, int32_t lb = CG_GREY, int32_t rr = CG_GREY, int32_t rg = CG_GREY, int32_t rb = CG_GREY, bool info_font = true, int32_t y_offset = 0);
+    void set_solid_color(int32_t r = C_RED, int32_t g = C_GREEN, int32_t b = C_BLUE);
+    void set_calendar_color(int32_t r = C_RED, int32_t g = C_BLACK, int32_t b = C_BLACK);
     #ifdef EHMTXv2_ADV_CLOCK
-      void set_clock_infotext_color(int lr = CG_GREY, int lg = CG_GREY, int lb = CG_GREY, int rr = CG_GREY, int rg = CG_GREY, int rb = CG_GREY, bool info_font = true, int y_offset = 0);
-      void set_date_infotext_color(int lr = CG_GREY, int lg = CG_GREY, int lb = CG_GREY, int rr = CG_GREY, int rg = CG_GREY, int rb = CG_GREY, bool info_font = true, int y_offset = 0);
-      void set_adv_clock_color(int hr = C_BLACK, int hg = C_BLACK, int hb = C_BLACK, int mr = C_BLACK, int mg = C_BLACK, int mb = C_BLACK, int sr = C_BLACK, int sg = C_BLACK, int sb = C_BLACK);
-      bool draw_clock(std::string format, esphome::display::BaseFont *font, Color color, int xpos = 0, int ypos = 0);
-      bool draw_date(std::string format, esphome::display::BaseFont *font, Color color, int xpos = 0, int ypos = 0);
+      void set_clock_infotext_color(int32_t lr = CG_GREY, int32_t lg = CG_GREY, int32_t lb = CG_GREY, int32_t rr = CG_GREY, int32_t rg = CG_GREY, int32_t rb = CG_GREY, bool info_font = true, int32_t y_offset = 0);
+      void set_date_infotext_color(int32_t lr = CG_GREY, int32_t lg = CG_GREY, int32_t lb = CG_GREY, int32_t rr = CG_GREY, int32_t rg = CG_GREY, int32_t rb = CG_GREY, bool info_font = true, int32_t y_offset = 0);
+      void set_adv_clock_color(int32_t hr = C_BLACK, int32_t hg = C_BLACK, int32_t hb = C_BLACK, int32_t mr = C_BLACK, int32_t mg = C_BLACK, int32_t mb = C_BLACK, int32_t sr = C_BLACK, int32_t sg = C_BLACK, int32_t sb = C_BLACK);
+      bool draw_clock(std::string format, esphome::display::BaseFont *font, Color color, int32_t xpos = 0, int32_t ypos = 0);
+      bool draw_date(std::string format, esphome::display::BaseFont *font, Color color, int32_t xpos = 0, int32_t ypos = 0);
     #endif
 
-    void show_alarm(int r = CA_RED, int g = CA_GREEN, int b = CA_BLUE, int s = 2);
-    void show_gauge(int v, int r = C_RED, int g = C_GREEN, int b = C_BLUE,int bgr = CG_GREY, int bgg = CG_GREY, int bgb = CG_GREY); // int because of register_service
+    void show_alarm(int32_t r = CA_RED, int32_t g = CA_GREEN, int32_t b = CA_BLUE, int32_t s = 2);
+    void show_gauge(int32_t v, int32_t r = C_RED, int32_t g = C_GREEN, int32_t b = C_BLUE,int32_t bgr = CG_GREY, int32_t bgg = CG_GREY, int32_t bgb = CG_GREY);
     void hide_gauge();
     void hide_rindicator();
     void hide_lindicator();
     void hide_icon_indicator();
     void hide_alarm();
-    void full_screen(std::string icon, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME);
-    void icon_screen(std::string icon, std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
-    void alert_screen(std::string icon, std::string text, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = CA_RED, int g = CA_GREEN, int b = CA_BLUE);
-    void rainbow_alert_screen(std::string icon, std::string text, int screen_time = D_SCREEN_TIME, bool default_font = true);
-    void icon_clock(std::string icon, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
-    void icon_date(std::string icon, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
-    void text_screen(std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
-    void clock_screen(int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
-    void date_screen(int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
-    void blank_screen(int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME);
-    void color_screen(int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
-    void text_screen_progress(std::string text, std::string value, int progress, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, bool value_color_as_progress = false, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
-    void icon_screen_progress(std::string icon, std::string text, int progress, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
-    void set_progressbar_color(std::string icon, int mode = MODE_ICON_PROGRESS, int r = C_BLACK, int g = C_BLACK, int b = C_BLACK, int bg_r = C_BLACK, int bg_g = C_BLACK, int bg_b = C_BLACK);
+    void full_screen(std::string icon, int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME);
+    void icon_screen(std::string icon, std::string text, int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME, bool default_font = true, int32_t r = C_RED, int32_t g = C_GREEN, int32_t b = C_BLUE);
+    void alert_screen(std::string icon, std::string text, int32_t screen_time = D_SCREEN_TIME, bool default_font = true, int32_t r = CA_RED, int32_t g = CA_GREEN, int32_t b = CA_BLUE);
+    void rainbow_alert_screen(std::string icon, std::string text, int32_t screen_time = D_SCREEN_TIME, bool default_font = true);
+    void icon_clock(std::string icon, int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME, bool default_font = true, int32_t r = C_RED, int32_t g = C_GREEN, int32_t b = C_BLUE);
+    void icon_date(std::string icon, int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME, bool default_font = true, int32_t r = C_RED, int32_t g = C_GREEN, int32_t b = C_BLUE);
+    void text_screen(std::string text, int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME, bool default_font = true, int32_t r = C_RED, int32_t g = C_GREEN, int32_t b = C_BLUE);
+    void clock_screen(int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME, bool default_font = true, int32_t r = C_RED, int32_t g = C_GREEN, int32_t b = C_BLUE);
+    void date_screen(int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME, bool default_font = true, int32_t r = C_RED, int32_t g = C_GREEN, int32_t b = C_BLUE);
+    void blank_screen(int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME);
+    void color_screen(int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME, int32_t r = C_RED, int32_t g = C_GREEN, int32_t b = C_BLUE);
+    void text_screen_progress(std::string text, std::string value, int32_t progress, int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME, bool default_font = true, bool value_color_as_progress = false, int32_t r = C_RED, int32_t g = C_GREEN, int32_t b = C_BLUE);
+    void icon_screen_progress(std::string icon, std::string text, int32_t progress, int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME, bool default_font = true, int32_t r = C_RED, int32_t g = C_GREEN, int32_t b = C_BLUE);
+    void set_progressbar_color(std::string icon, int32_t mode = MODE_ICON_PROGRESS, int32_t r = C_BLACK, int32_t g = C_BLACK, int32_t b = C_BLACK, int32_t bg_r = C_BLACK, int32_t bg_g = C_BLACK, int32_t bg_b = C_BLACK);
 
-    void icon_text_screen(std::string icon, std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
-    void rainbow_icon_text_screen(std::string icon, std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true);
+    void icon_text_screen(std::string icon, std::string text, int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME, bool default_font = true, int32_t r = C_RED, int32_t g = C_GREEN, int32_t b = C_BLUE);
+    void rainbow_icon_text_screen(std::string icon, std::string text, int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME, bool default_font = true);
 
-    void bitmap_stack(std::string icons, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME);
+    void bitmap_stack(std::string icons, int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME);
 
-    void icon_prognosis_screen(std::string icon, std::string text, std::string prognosis, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true);
-    void icon_prognosis_screen_rgb(std::string icon, std::string text, std::string prognosis, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
+    void icon_prognosis_screen(std::string icon, std::string text, std::string prognosis, int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME, bool default_font = true);
+    void icon_prognosis_screen_rgb(std::string icon, std::string text, std::string prognosis, int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME, bool default_font = true, int32_t r = C_RED, int32_t g = C_GREEN, int32_t b = C_BLUE);
 
-    void bitmap_screen(std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME);
+    void bitmap_screen(std::string text, int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME);
     void color_gauge(std::string text);
-    void bitmap_small(std::string icon, std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true, int r = C_RED, int g = C_GREEN, int b = C_BLUE);
-    void rainbow_bitmap_small(std::string icon, std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true);
-    void rainbow_icon_screen(std::string icon_name, std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true);
-    void rainbow_text_screen(std::string text, int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true);
-    void rainbow_clock_screen(int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true);
-    void rainbow_date_screen(int lifetime = D_LIFETIME, int screen_time = D_SCREEN_TIME, bool default_font = true);
-    void del_screen(std::string icon, int mode = MODE_ICON_SCREEN);
+    void bitmap_small(std::string icon, std::string text, int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME, bool default_font = true, int32_t r = C_RED, int32_t g = C_GREEN, int32_t b = C_BLUE);
+    void rainbow_bitmap_small(std::string icon, std::string text, int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME, bool default_font = true);
+    void rainbow_icon_screen(std::string icon_name, std::string text, int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME, bool default_font = true);
+    void rainbow_text_screen(std::string text, int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME, bool default_font = true);
+    void rainbow_clock_screen(int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME, bool default_font = true);
+    void rainbow_date_screen(int32_t lifetime = D_LIFETIME, int32_t screen_time = D_SCREEN_TIME, bool default_font = true);
+    void del_screen(std::string icon, int32_t mode = MODE_ICON_SCREEN);
 
     void draw_gauge();
     void draw_alarm();
@@ -302,27 +302,27 @@ namespace esphome
     void draw_icon_indicator();
 
     #ifdef EHMTXv2_RAINBOW_SHIMMER
-      void draw_rainbow_text(std::string text, esphome::display::BaseFont *font, int xpos, int ypos);
+      void draw_rainbow_text(std::string text, esphome::display::BaseFont *font, int32_t xpos, int32_t ypos);
     #endif
-    void draw_text(std::string text, esphome::display::BaseFont *font, Color color, int xpos, int ypos);
+    void draw_text(std::string text, esphome::display::BaseFont *font, Color color, int32_t xpos, int32_t ypos);
 
     void set_replace_time_date_active(bool b=false);
     void set_weekday_char_count(uint8_t i);
     bool replace_time_date_active;
     std::string replace_time_date(std::string time_date);
     uint8_t weekday_char_count;
-    std::string GetWeekdayChar(int position);
-    std::string GetTextChar(std::string text, int position);
+    std::string GetWeekdayChar(int32_t position);
+    std::string GetTextChar(std::string text, int32_t position);
     #ifdef EHMTXv2_RAINBOW_SHIMMER
-      int GetTextCharCount(std::string text);
+      int32_t GetTextCharCount(std::string text);
     #endif
 
-    int GetTextBounds(esphome::display::BaseFont *font, const char *buffer);
-    int GetTextWidth(esphome::display::BaseFont *font, const char* formatting, const char raw_char);
-    int GetTextWidth(esphome::display::BaseFont *font, const char* formatting, const char *raw_text);
-    int GetTextWidth(esphome::display::BaseFont *font, const char* formatting, const int raw_int);
-    int GetTextWidth(esphome::display::BaseFont *font, const char* formatting, const float raw_float);
-    int GetTextWidth(esphome::display::BaseFont *font, const char* formatting, esphome::ESPTime time);
+    int32_t GetTextBounds(esphome::display::BaseFont *font, const char *buffer);
+    int32_t GetTextWidth(esphome::display::BaseFont *font, const char* formatting, const char raw_char);
+    int32_t GetTextWidth(esphome::display::BaseFont *font, const char* formatting, const char *raw_text);
+    int32_t GetTextWidth(esphome::display::BaseFont *font, const char* formatting, const int32_t raw_int);
+    int32_t GetTextWidth(esphome::display::BaseFont *font, const char* formatting, const float raw_float);
+    int32_t GetTextWidth(esphome::display::BaseFont *font, const char* formatting, esphome::ESPTime time);
 
     void add_on_next_screen_trigger(EHMTXNextScreenTrigger *t) { this->on_next_screen_triggers_.push_back(t); }
     void add_on_empty_queue_trigger(EHMTXEmptyQueueTrigger *t) { this->on_empty_queue_triggers_.push_back(t); }
@@ -380,10 +380,10 @@ namespace esphome
     void hold_slot(uint8_t _sec);
     void calc_scroll_time(std::string text, uint16_t screen_time);
     void calc_scroll_time(uint8_t icon_count, uint16_t screen_time);
-    int xpos();
-    int xpos(uint8_t item);
-    int ypos();
-    int ypos(uint8_t item);
+    int32_t xpos();
+    int32_t xpos(uint8_t item);
+    int32_t ypos();
+    int32_t ypos(uint8_t item);
   };
 
   class EHMTXNextScreenTrigger : public Trigger<std::string, std::string>
@@ -475,7 +475,7 @@ namespace esphome
    * @param frame_duration time per frame
    * @param transparency
    */
-    EHMTX_Icon(const uint8_t *data_start, int width, int height, uint32_t animation_frame_count, esphome::image::ImageType type, std::string icon_name, bool revers, uint16_t frame_duration, esphome::image::Transparency transparency);
+    EHMTX_Icon(const uint8_t *data_start, int32_t width, int32_t height, uint32_t animation_frame_count, esphome::image::ImageType type, std::string icon_name, bool revers, uint16_t frame_duration, esphome::image::Transparency transparency);
 #ifdef USE_ESP32
     PROGMEM std::string name;
 #endif

--- a/components/ehmtxv2/EHMTX_icons.cpp
+++ b/components/ehmtxv2/EHMTX_icons.cpp
@@ -3,7 +3,7 @@
 namespace esphome
 {
 
-  EHMTX_Icon::EHMTX_Icon(const uint8_t *data_start, int width, int height, uint32_t animation_frame_count, esphome::image::ImageType type, std::string icon_name, bool revers, uint16_t frame_duration, esphome::image::Transparency transparency)
+  EHMTX_Icon::EHMTX_Icon(const uint8_t *data_start, int32_t width, int32_t height, uint32_t animation_frame_count, esphome::image::ImageType type, std::string icon_name, bool revers, uint16_t frame_duration, esphome::image::Transparency transparency)
       : Animation(data_start, width, height, animation_frame_count, type, transparency)
   {
     this->name = icon_name;

--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -185,11 +185,11 @@ namespace esphome
     }
   }
 
-  int EHMTX_queue::xpos()
+  int32_t EHMTX_queue::xpos()
   {
     uint8_t width = 32;
     uint8_t startx = 0;
-    int result = 0;
+    int32_t result = 0;
     switch (this->mode)
     {
     case MODE_RAINBOW_ICON:
@@ -263,7 +263,7 @@ namespace esphome
     return (static_cast<uint16_t>(r) << 8) | g;
   }
 
-  uint8_t is_tick(int step, uint8_t &state)
+  uint8_t is_tick(int32_t step, uint8_t &state)
   {
     if (step % 2 == state)
     {
@@ -273,10 +273,10 @@ namespace esphome
     return 1;
   }
 
-  int EHMTX_queue::xpos(uint8_t item)
+  int32_t EHMTX_queue::xpos(uint8_t item)
   {
     uint8_t width = 32;
-    int result = width - this->config_->scroll_step + item * 9;
+    int32_t result = width - this->config_->scroll_step + item * 9;
 
     if (this->icon < 5)
     {
@@ -347,7 +347,7 @@ namespace esphome
     return result;
   }
 
-  int EHMTX_queue::ypos()
+  int32_t EHMTX_queue::ypos()
   {
 #ifdef EHMTXv2_USE_VERTICAL_SCROLL
     if (this->config_->queue_count() <= 1)
@@ -372,7 +372,7 @@ namespace esphome
 #endif
   }
 
-  int EHMTX_queue::ypos(uint8_t item)
+  int32_t EHMTX_queue::ypos(uint8_t item)
   {
     uint8_t height = 8;
 
@@ -757,7 +757,7 @@ namespace esphome
             }
 #endif
 
-            int mode = 0;
+            int32_t mode = 0;
             std::size_t pos = icon_name.find("#");
             if (pos != std::string::npos)
             {
@@ -776,8 +776,8 @@ namespace esphome
               uint8_t d = this->config_->clock->now().day_of_month;
 
               // The symbol consists of a visible part, and an empty area to the right with a width of one point.
-              uint8_t l_width = this->config_->GetTextWidth(info_font, "%d", d / 10 % 10);
-              uint8_t r_width = this->config_->GetTextWidth(info_font, "%d", d % 10);
+              uint8_t l_width = this->config_->GetTextWidth(info_font, "%d", (int32_t) (d / 10 % 10));
+              uint8_t r_width = this->config_->GetTextWidth(info_font, "%d", (int32_t) (d % 10));
               switch (mode)
               {
               // To the center
@@ -1054,7 +1054,7 @@ namespace esphome
         this->config_->display->start_clipping(0,0,0,0);
         if (this->icon != BLANKICON)
         {
-          int x = 0;
+          int32_t x = 0;
           if (this->pixels_ > 23)
           {
             if (this->xpos() > 23)


### PR DESCRIPTION
Building with a configuration file for esp-idf like

```yaml
esp32:
  board: esp32-s3-devkitc-1
  variant: esp32s3
  flash_size: 8MB
  framework:
    type: esp-idf
    version: recommended
```
currently fails with errors like:
```
Building .pioenvs\test-esp-build\bootloader.bin
esptool.py v4.8.1.1
Creating esp32s3 image...
Merged 1 ELF section
Successfully created esp32s3 image.
Linking .pioenvs\test-esp-build\firmware.elf
.../.platformio/packages/toolchain-xtensa-esp32s3/bin/../lib/gcc/xtensa-esp32s3-elf/12.2.0/../../../../xtensa-esp32s3-elf/bin/ld.exe: .pioenvs/test-esp-build/src/esphome/components/ehmtxv2/EHMTX.cpp.o:(.literal._ZN7esphome3api15UserServiceBaseIJiiiiiiiEE28encode_list_service_responseEv[_ZN7esphome3api15UserServiceBaseIJiiiiiiiEE28encode_list_service_responseEv]+0x0): undefined reference to `esphome::api::enums::ServiceArgType esphome::api::to_service_arg_type<int>()'
.../.platformio/packages/toolchain-xtensa-esp32s3/bin/../lib/gcc/xtensa-esp32s3-elf/12.2.0/../../../../xtensa-esp32s3-elf/bin/ld.exe: .pioenvs/test-esp-build/src/esphome/components/ehmtxv2/EHMTX.cpp.o:(.literal._ZN7esphome3api15UserServiceBaseIJiiiiiiiEE15execute_serviceERKNS0_21ExecuteServiceRequestE[_ZN7esphome3api15UserServiceBaseIJiiiiiiiEE15execute_serviceERKNS0_21ExecuteServiceRequestE]+0x0): undefined reference to `int esphome::api::get_execute_arg_value<int>(esphome::api::ExecuteServiceArgument const&)'
.../.platformio/packages/toolchain-xtensa-esp32s3/bin/../lib/gcc/xtensa-esp32s3-elf/12.2.0/../../../../xtensa-esp32s3-elf/bin/ld.exe: .pioenvs/test-esp-build/src/esphome/components/ehmtxv2/EHMTX.cpp.o: in function `esphome::api::UserServiceBase<int, int, int, int, int, int, int>::encode_list_service_response()':
...\.esphome\build\test-esp-build/src/esphome\components\api/user_services.h:34: undefined reference to `esphome::api::enums::ServiceArgType esphome::api::to_service_arg_type<int>()'

.../.platformio/packages/toolchain-xtensa-esp32s3/bin/../lib/gcc/xtensa-esp32s3-elf/12.2.0/../../../../xtensa-esp32s3-elf/bin/ld.exe: D:\esphome-MaTriXv2-pr\.esphome\build\test-esp-build/src/esphome\components\api/user_services.h:35: undefined reference to `esphome::api::enums::ServiceArgType esphome::api::to_service_arg_type<int>()'
.../.platformio/packages/toolchain-xtensa-esp32s3/bin/../lib/gcc/xtensa-esp32s3-elf/12.2.0/../../../../xtensa-esp32s3-elf/bin/ld.exe: D:\esphome-MaTriXv2-pr\.esphome\build\test-esp-build/src/esphome\components\api/user_services.h:35: undefined reference to `esphome::api::enums::ServiceArgType esphome::api::to_service_arg_type<int>()'
.../.platformio/packages/toolchain-xtensa-esp32s3/bin/../lib/gcc/xtensa-esp32s3-elf/12.2.0/../../../../xtensa-esp32s3-elf/bin/ld.exe: D:\esphome-MaTriXv2-pr\.esphome\build\test-esp-build/src/esphome\components\api/user_services.h:35: undefined reference to `esphome::api::enums::ServiceArgType esphome::api::to_service_arg_type<int>()'
.../.platformio/packages/toolchain-xtensa-esp32s3/bin/../lib/gcc/xtensa-esp32s3-elf/12.2.0/../../../../xtensa-esp32s3-elf/bin/ld.exe: D:\esphome-MaTriXv2-pr\.esphome\build\test-esp-build/src/esphome\components\api/user_services.h:35: undefined reference to `esphome::api::enums::ServiceArgType esphome::api::to_service_arg_type<int>()'
.../.platformio/packages/toolchain-xtensa-esp32s3/bin/../lib/gcc/xtensa-esp32s3-elf/12.2.0/../../../../xtensa-esp32s3-elf/bin/ld.exe: .pioenvs/test-esp-build/src/esphome/components/ehmtxv2/EHMTX.cpp.o:D:\esphome-MaTriXv2-pr\.esphome\build\test-esp-build/src/esphome\components\api/user_services.h:35: more undefined references to `esphome::api::enums::ServiceArgType esphome::api::to_service_arg_type<int>()' follow
.../.platformio/packages/toolchain-xtensa-esp32s3/bin/../lib/gcc/xtensa-esp32s3-elf/12.2.0/../../../../xtensa-esp32s3-elf/bin/ld.exe: .pioenvs/test-esp-build/src/esphome/components/ehmtxv2/EHMTX.cpp.o: in function `void esphome::api::UserServiceBase<int, int, int, int, int, int, int>::execute_<0, 1, 2, 3, 4, 5, 6>(std::vector<esphome::api::ExecuteServiceArgument, std::allocator<esphome::api::ExecuteServiceArgument> >, esphome::seq<0, 1, 2, 3, 4, 5, 6>)':
...\.esphome\build\test-esp-build/src/esphome\components\api/user_services.h:57: undefined reference to `int esphome::api::get_execute_arg_value<int>(esphome::api::ExecuteServiceArgument const&)'

.../.platformio/packages/toolchain-xtensa-esp32s3/bin/../lib/gcc/xtensa-esp32s3-elf/12.2.0/../../../../xtensa-esp32s3-elf/bin/ld.exe: D:\esphome-MaTriXv2-pr\.esphome\build\test-esp-build/src/esphome\components\api/user_services.h:57: undefined reference to `int esphome::api::get_execute_arg_value<int>(esphome::api::ExecuteServiceArgument const&)'
.../.platformio/packages/toolchain-xtensa-esp32s3/bin/../lib/gcc/xtensa-esp32s3-elf/12.2.0/../../../../xtensa-esp32s3-elf/bin/ld.exe: D:\esphome-MaTriXv2-pr\.esphome\build\test-esp-build/src/esphome\components\api/user_services.h:57: undefined reference to `int esphome::api::get_execute_arg_value<int>(esphome::api::ExecuteServiceArgument const&)'
.../.platformio/packages/toolchain-xtensa-esp32s3/bin/../lib/gcc/xtensa-esp32s3-elf/12.2.0/../../../../xtensa-esp32s3-elf/bin/ld.exe: D:\esphome-MaTriXv2-pr\.esphome\build\test-esp-build/src/esphome\components\api/user_services.h:57: undefined reference to `int esphome::api::get_execute_arg_value<int>(esphome::api::ExecuteServiceArgument const&)'
.../.platformio/packages/toolchain-xtensa-esp32s3/bin/../lib/gcc/xtensa-esp32s3-elf/12.2.0/../../../../xtensa-esp32s3-elf/bin/ld.exe: D:\esphome-MaTriXv2-pr\.esphome\build\test-esp-build/src/esphome\components\api/user_services.h:57: undefined reference to `int esphome::api::get_execute_arg_value<int>(esphome::api::ExecuteServiceArgument const&)'
.../.platformio/packages/toolchain-xtensa-esp32s3/bin/../lib/gcc/xtensa-esp32s3-elf/12.2.0/../../../../xtensa-esp32s3-elf/bin/ld.exe: .pioenvs/test-esp-build/src/esphome/components/ehmtxv2/EHMTX.cpp.o:D:\esphome-MaTriXv2-pr\.esphome\build\test-esp-build/src/esphome\components\api/user_services.h:57: more undefined references to `int esphome::api::get_execute_arg_value<int>(esphome::api::ExecuteServiceArgument const&)' follow
```

The problem is that the esphome file
```
esphome\components\api/user_services.h
```
does not contain template instantiations for a parameter type of **int**. When compiling for arduino **int** an **int32_t** are the same but not for esp-idf.
```
template<> enums::ServiceArgType to_service_arg_type<bool>() { return enums::SERVICE_ARG_TYPE_BOOL; }
template<> enums::ServiceArgType to_service_arg_type<int32_t>() { return enums::SERVICE_ARG_TYPE_INT; }
template<> enums::ServiceArgType to_service_arg_type<float>() { return enums::SERVICE_ARG_TYPE_FLOAT; }
template<> enums::ServiceArgType to_service_arg_type<std::string>() { return enums::SERVICE_ARG_TYPE_STRING; }
template<> enums::ServiceArgType to_service_arg_type<std::vector<bool>>() { return enums::SERVICE_ARG_TYPE_BOOL_ARRAY; }
template<> enums::ServiceArgType to_service_arg_type<std::vector<int32_t>>() {
  return enums::SERVICE_ARG_TYPE_INT_ARRAY;
}
template<> enums::ServiceArgType to_service_arg_type<std::vector<float>>() {
  return enums::SERVICE_ARG_TYPE_FLOAT_ARRAY;
}
template<> enums::ServiceArgType to_service_arg_type<std::vector<std::string>>() {
  return enums::SERVICE_ARG_TYPE_STRING_ARRAY;
}
```

This PR replaces the usage of **int** with **int32_t** so it can be built for both platforms arduino and esp-idf.

- [x] Code has been compiled for framework arduino, uploaded and executed without problems on a Seeed Studio XIAO ESP32S3.
- [x] Code has been compiled for framework esp-idf, uploaded and executed without problems on a Seeed Studio XIAO ESP32S3.

### Versions:
- ESPHome 2025.5.0-dev
- framework-espidf @ 3.50106.0 (5.1.6)
- framework-arduinoespressif32 @ 3.20005.220925 (2.0.5)