### PR TITLE
Added string formatting macro to build on esp-idf and esp32s3.

### DIFF
--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -4,13 +4,14 @@
 #define USE_Fireplugin
 #include "esphome/components/time/real_time_clock.h"
 
+#ifndef F
+  #define F(x) (x)
+#endif
+
 #if defined CONFIG_IDF_TARGET_ESP32S3 || defined CONFIG_IDF_TARGET_ESP32
   #undef EHMTXv2_RAINBOW_SHIMMER
   #pragma warning ( "with IDF-Framework no Fire and Rainbowshimmer") 
   #undef USE_Fireplugin
-  #ifndef F
-  //  #define F(x) (x)
-  #endif
 #endif
 
 const uint8_t MAXQUEUE = 24;


### PR DESCRIPTION
Building for the combination esp-idf and esp32s3currently fails with errors like:

```
src/esphome/components/ehmtxv2/EHMTX.cpp:1602:61: error: 'F' was not declared in this scope
 1602 |     ESP_LOGI(TAG, "status display %s", this->show_display ? F("on") : F("off"));
      |                                                             ^
src/esphome/core/log.h:110:99: note: in definition of macro 'esph_log_i'
  110 |   ::esphome::esp_log_printf_(ESPHOME_LOG_LEVEL_INFO, tag, __LINE__, ESPHOME_LOG_FORMAT(format), ##__VA_ARGS__)
      |                                                                                                   ^~~~~~~~~~~
src/esphome/components/ehmtxv2/EHMTX.cpp:1602:5: note: in expansion of macro 'ESP_LOGI'
 1602 |     ESP_LOGI(TAG, "status display %s", this->show_display ? F("on") : F("off"));
      |     ^~~~~~~~
src/esphome/components/ehmtxv2/EHMTX.cpp: In member function 'void esphome::EHMTX::set_replace_time_date_active(bool)':
```
This is because **get_status** depends on the macro definition:
```
  void EHMTX::get_status()
  {
    time_t ts = this->clock->now().timestamp;
...
    ESP_LOGI(TAG, "status date format: %s", EHMTXv2_DATE_FORMAT);
    ESP_LOGI(TAG, "status display %s", this->show_display ? F("on") : F("off"));
    ESP_LOGI(TAG, "status night mode %s", this->night_mode ? F("on") : F("off"));
    ESP_LOGI(TAG, "status weekday accent %s", this->weekday_accent ? F("on") : F("off"));
    ESP_LOGI(TAG, "status replace time and date %s", this->replace_time_date_active ? F("on") : F("off"));

    this->queue_status();
  }
```
This PR adds back the macro for string formatting for esp-idf and esp32s3.
- [x] Code has been compiled for framework esp-idf, uploaded and executed without problems on a Seeed Studio XIAO ESP32S3.