### PR TITLE
Avoid blank screen for 15 seconds after empty queue.

### DIFF
--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -1453,7 +1453,13 @@ namespace esphome
           {
               ESP_LOGD(TAG, "on_empty_queue trigger");
               t->process();
-            } 
+          }
+          // check if automation has enqueued a new element
+          this->screen_pointer = find_oldest_queue_element();
+          if (this->screen_pointer != MAXQUEUE)
+          {
+            this->next_action_time = ts + this->queue[this->screen_pointer]->screen_time_;
+          }
         }
       }
 

--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -1312,6 +1312,108 @@ namespace esphome
 #endif
   }
 
+  void EHMTX::tick_next_screen(float ts)
+  {
+    if (this->screen_pointer == MAXQUEUE)
+    {
+      return;
+    }
+
+    this->queue[this->screen_pointer]->last_time = ts;
+    // todo nur bei animationen
+    if (this->queue[this->screen_pointer]->mode == MODE_BITMAP_STACK_SCREEN && this->queue[this->screen_pointer]->sbitmap != NULL)
+    {
+      for (uint8_t i = 0; i < this->queue[this->screen_pointer]->icon; i++)
+      {
+        this->icons[this->queue[this->screen_pointer]->sbitmap[i].b]->set_frame(0);
+        this->queue[this->screen_pointer]->sbitmap[i] = Color(127, 255, this->queue[this->screen_pointer]->sbitmap[i].b, 5);
+        this->queue[this->screen_pointer]->default_font = false;
+      }
+    }
+    else if (this->queue[this->screen_pointer]->icon < this->icon_count)
+    {
+      this->icons[this->queue[this->screen_pointer]->icon]->set_frame(0);
+    }
+    this->next_action_time = this->queue[this->screen_pointer]->last_time + this->queue[this->screen_pointer]->screen_time_;
+    // Todo switch for Triggers
+    if (this->queue[this->screen_pointer]->mode == MODE_CLOCK)
+    {
+      for (auto *t : on_next_clock_triggers_)
+      {
+        t->process();
+      }
+    }
+    else
+    {
+      for (auto *t : on_next_screen_triggers_)
+      {
+        ESP_LOGD(TAG, "on_next_screen trigger");
+        std::string infotext = "";
+        switch (this->queue[this->screen_pointer]->mode)
+        {
+        case MODE_EMPTY:
+          infotext = "empty";
+          break;
+        case MODE_BLANK:
+          infotext = "blank";
+          break;
+        case MODE_COLOR:
+          infotext = "color";
+          break;
+        case MODE_CLOCK:
+        case MODE_RAINBOW_CLOCK:
+          infotext = "clock";
+          break;
+        case MODE_DATE:
+        case MODE_RAINBOW_DATE:
+          infotext = "date";
+          break;
+        case MODE_FULL_SCREEN:
+          infotext = "full screen " + this->queue[this->screen_pointer]->icon_name;
+          break;
+        case MODE_ICON_SCREEN:
+        case MODE_RAINBOW_ICON:
+        case MODE_ICON_CLOCK:
+        case MODE_ICON_DATE:
+        case MODE_ICON_PROGRESS:
+        case MODE_ICON_TEXT_SCREEN:
+        case MODE_RAINBOW_ICON_TEXT_SCREEN:
+        case MODE_TEXT_PROGRESS:
+        case MODE_PROGNOSIS_SCREEN:
+          infotext = this->queue[this->screen_pointer]->icon_name.c_str();
+          break;
+        case MODE_ALERT_SCREEN:
+        case MODE_RAINBOW_ALERT_SCREEN:
+          infotext = ("alert: " + this->queue[this->screen_pointer]->icon_name).c_str();
+          break;
+        case MODE_GRAPH_SCREEN:
+          infotext = ("graph: " + this->queue[this->screen_pointer]->icon_name).c_str();
+          break;
+        case MODE_RAINBOW_TEXT:
+        case MODE_TEXT_SCREEN:
+          infotext = "text";
+          break;
+        case MODE_BITMAP_SMALL:
+        case MODE_RAINBOW_BITMAP_SMALL:
+          infotext = ("bitmap small: " + this->queue[this->screen_pointer]->icon_name).c_str();
+          break;
+        case MODE_BITMAP_SCREEN:
+          infotext = ("bitmap: " + this->queue[this->screen_pointer]->icon_name).c_str();
+          break;
+        case MODE_BITMAP_STACK_SCREEN:
+          infotext = ("bitmap stack: " + this->queue[this->screen_pointer]->text).c_str();
+          break;
+        case MODE_FIRE:
+          infotext = "fire";
+          break;
+        default:
+          break;
+        }
+        t->process(infotext, this->queue[this->screen_pointer]->text);
+      }
+    }
+  }
+
   void EHMTX::tick()
   {
     if (millis() - this->last_rainbow_time >= EHMTXv2_RAINBOW_INTERVAL)
@@ -1352,99 +1454,7 @@ namespace esphome
 
         if (this->screen_pointer != MAXQUEUE)
         {
-          this->queue[this->screen_pointer]->last_time = ts;
-          // todo nur bei animationen
-          if (this->queue[this->screen_pointer]->mode == MODE_BITMAP_STACK_SCREEN && this->queue[this->screen_pointer]->sbitmap != NULL)
-          {
-            for (uint8_t i = 0; i < this->queue[this->screen_pointer]->icon; i++)
-            {
-              this->icons[this->queue[this->screen_pointer]->sbitmap[i].b]->set_frame(0);
-              this->queue[this->screen_pointer]->sbitmap[i] = Color(127, 255, this->queue[this->screen_pointer]->sbitmap[i].b, 5);
-              this->queue[this->screen_pointer]->default_font = false;
-            }
-          }
-          else if (this->queue[this->screen_pointer]->icon < this->icon_count)
-          {
-            this->icons[this->queue[this->screen_pointer]->icon]->set_frame(0);
-          }
-          this->next_action_time = this->queue[this->screen_pointer]->last_time + this->queue[this->screen_pointer]->screen_time_;
-          // Todo switch for Triggers
-          if (this->queue[this->screen_pointer]->mode == MODE_CLOCK)
-          {
-            for (auto *t : on_next_clock_triggers_)
-            {
-              t->process();
-            }
-          }
-          else
-          {
-            for (auto *t : on_next_screen_triggers_)
-            {
-              ESP_LOGD(TAG, "on_next_screen trigger");
-              std::string infotext = "";
-              switch (this->queue[this->screen_pointer]->mode)
-              {
-              case MODE_EMPTY:
-                infotext = "empty";
-                break;
-              case MODE_BLANK:
-                infotext = "blank";
-                break;
-              case MODE_COLOR:
-                infotext = "color";
-                break;
-              case MODE_CLOCK:
-              case MODE_RAINBOW_CLOCK:
-                infotext = "clock";
-                break;
-              case MODE_DATE:
-              case MODE_RAINBOW_DATE:
-                infotext = "date";
-                break;
-              case MODE_FULL_SCREEN:
-                infotext = "full screen " + this->queue[this->screen_pointer]->icon_name;
-                break;
-              case MODE_ICON_SCREEN:
-              case MODE_RAINBOW_ICON:
-              case MODE_ICON_CLOCK:
-              case MODE_ICON_DATE:
-              case MODE_ICON_PROGRESS:
-              case MODE_ICON_TEXT_SCREEN:
-              case MODE_RAINBOW_ICON_TEXT_SCREEN:
-              case MODE_TEXT_PROGRESS:
-              case MODE_PROGNOSIS_SCREEN:
-                infotext = this->queue[this->screen_pointer]->icon_name.c_str();
-                break;
-              case MODE_ALERT_SCREEN:
-              case MODE_RAINBOW_ALERT_SCREEN:
-                infotext = ("alert: " + this->queue[this->screen_pointer]->icon_name).c_str();
-                break;
-              case MODE_GRAPH_SCREEN:
-                infotext = ("graph: " + this->queue[this->screen_pointer]->icon_name).c_str();
-                break;
-              case MODE_RAINBOW_TEXT:
-              case MODE_TEXT_SCREEN:
-                infotext = "text";
-                break;
-              case MODE_BITMAP_SMALL:
-              case MODE_RAINBOW_BITMAP_SMALL:
-                infotext = ("bitmap small: " + this->queue[this->screen_pointer]->icon_name).c_str();
-                break;
-              case MODE_BITMAP_SCREEN:
-                infotext = ("bitmap: " + this->queue[this->screen_pointer]->icon_name).c_str();
-                break;
-              case MODE_BITMAP_STACK_SCREEN:
-                infotext = ("bitmap stack: " + this->queue[this->screen_pointer]->text).c_str();
-                break;
-              case MODE_FIRE:
-                infotext = "fire";
-                break;
-              default:
-                break;
-              }
-              t->process(infotext, this->queue[this->screen_pointer]->text);
-            }
-          }
+          tick_next_screen(ts);
         }
         else
         {
@@ -1458,7 +1468,7 @@ namespace esphome
           this->screen_pointer = find_oldest_queue_element();
           if (this->screen_pointer != MAXQUEUE)
           {
-            this->next_action_time = ts + this->queue[this->screen_pointer]->screen_time_;
+            tick_next_screen(ts);
           }
         }
       }

--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -205,6 +205,7 @@ namespace esphome
     void draw_day_of_week(int32_t ypos = 0, bool small = false);
     void show_all_icons();
     float get_tick();
+    void tick_next_screen(float ts);
     void tick();
     void draw();
     void get_status();


### PR DESCRIPTION
When all elements are expired and the queue is empty, new elements may be added through the *on_empty_queue* automation. The new elements are not shown directly, instead a blank screen is shown for 15 seconds.

Log output:
```
[10:53:57][C][EHMTXv2:3121]: EspHoMatriXv2 version: 2025.2.1
[10:53:57][C][EHMTXv2:3122]: Icons: 1 of 100
[10:53:57][C][EHMTXv2:3123]: Clock interval: 0 s
[10:53:57][C][EHMTXv2:3124]: Date format: %d/%m
[10:53:57][C][EHMTXv2:3125]: Time format: %H:%M
[10:53:57][C][EHMTXv2:3126]: Interval (ms) scroll: 80
[10:53:57][C][EHMTXv2:3129]: Show day of week
[10:53:57][C][EHMTXv2:3137]: Weekstart: Monday
[10:53:57][C][EHMTXv2:3138]: Weekdays: SOMODIMIDOFRSA Count: 14
[10:53:57][C][EHMTXv2:3139]: Display: On
[10:53:57][C][EHMTXv2:3140]: Night mode: Off
[10:53:57][C][EHMTXv2:3141]: Weekday accent: Off
[10:53:57][C][EHMTXv2:3142]: Replace Time and Date: Off
[10:54:06][D][EHMTXv2:1184]: remove expired queue element: slot 0: mode: 2 icon_name:  text:
[10:54:06][D][EHMTXv2:098]: empty slot
[10:54:06][D][EHMTXv2:1454]: on_empty_queue trigger
[10:54:06][D][EHMTXv2:2382]: free_screen: found by endtime 0
[10:54:06][D][EHMTXv2:2180]: clock_screen_color lifetime: 0 screen_time: 10 red: 240 green: 240 blue: 240
[10:54:06][D][EHMTXv2:107]: queue: clock for: 10.0 sec
[10:54:21][D][EHMTXv2:1184]: remove expired queue element: slot 0: mode: 2 icon_name:  text:
[10:54:21][D][EHMTXv2:098]: empty slot
[10:54:21][D][EHMTXv2:1454]: on_empty_queue trigger
[10:54:21][D][EHMTXv2:2382]: free_screen: found by endtime 0
[10:54:21][D][EHMTXv2:2180]: clock_screen_color lifetime: 0 screen_time: 10 red: 240 green: 240 blue: 240
[10:54:21][D][EHMTXv2:107]: queue: clock for: 10.0 sec
[10:54:36][D][EHMTXv2:1184]: remove expired queue element: slot 0: mode: 2 icon_name:  text:
[10:54:36][D][EHMTXv2:098]: empty slot
[10:54:36][D][EHMTXv2:1454]: on_empty_queue trigger
[10:54:36][D][EHMTXv2:2382]: free_screen: found by endtime 0
[10:54:36][D][EHMTXv2:2180]: clock_screen_color lifetime: 0 screen_time: 10 red: 240 green: 240 blue: 240
[10:54:36][D][EHMTXv2:107]: queue: clock for: 10.0 sec
```


The following configuration exposes the behavior:
```yaml
ehmtxv2:
  id: rgb8x32
  brightness: 180
  matrix_component: ehmtx_display
  time_component: ehmtx_time
  icons2html: false

  default_font_id: default_font
  default_font_yoffset: 6

  special_font_id: special_font
  special_font_yoffset: 8

  show_seconds: false
  show_dow: true
  always_show_rl_indicators: false
  date_format: "%d/%m"
  icons: 
    - id: error
      lameid: 40530
  on_empty_queue:
    lambda: |-
      id(rgb8x32)->clock_screen(0,10);
  on_start_running:
    lambda: |-
      id(rgb8x32)->clock_screen(0,10);
  on_next_screen:
    lambda: |-
      ESP_LOGD("EHMTXv2", "ON_NEXT_SCREEN: %s", icon.c_str());
  on_next_clock:
    lambda: |-
      ESP_LOGD("EHMTXv2", "ON_NEXT_CLOCK.");
```
This PR sets the *screen_pointer* when *on_empty_queue* automation enqueued a new element and invokes *on_next_clock* or *on_next_screen* for the new element.

### Log output with PR applied
```
[11:45:35][C][EHMTXv2:3137]: EspHoMatriXv2 version: 2025.2.1
[11:45:35][C][EHMTXv2:3138]: Icons: 1 of 100
[11:45:35][C][EHMTXv2:3139]: Clock interval: 0 s
[11:45:35][C][EHMTXv2:3140]: Date format: %d/%m
[11:45:35][C][EHMTXv2:3141]: Time format: %H:%M
[11:45:35][C][EHMTXv2:3142]: Interval (ms) scroll: 80
[11:45:35][C][EHMTXv2:3145]: Show day of week
[11:45:35][C][EHMTXv2:3153]: Weekstart: Monday
[11:45:35][C][EHMTXv2:3154]: Weekdays: SOMODIMIDOFRSA Count: 14
[11:45:35][C][EHMTXv2:3155]: Display: On
[11:45:35][C][EHMTXv2:3156]: Night mode: Off
[11:45:35][C][EHMTXv2:3157]: Weekday accent: Off
[11:45:35][C][EHMTXv2:3158]: Replace Time and Date: Off
[11:45:43][D][EHMTXv2:1184]: remove expired queue element: slot 0: mode: 2 icon_name:  text:
[11:45:43][D][EHMTXv2:098]: empty slot
[11:45:43][D][EHMTXv2:1464]: on_empty_queue trigger
[11:45:43][D][EHMTXv2:2398]: free_screen: found by endtime 0
[11:45:43][D][EHMTXv2:2196]: clock_screen_color lifetime: 0 screen_time: 10 red: 240 green: 240 blue: 240
[11:45:43][D][EHMTXv2:107]: queue: clock for: 10.0 sec
[11:45:43][D][EHMTXv2:1113]: oldest queue element is: 0/1
[11:45:43][D][EHMTXv2:107]: queue: clock for: 10.0 sec
[11:45:43][D][EHMTXv2:046]: ON_NEXT_CLOCK.
[11:45:53][D][EHMTXv2:1184]: remove expired queue element: slot 0: mode: 2 icon_name:  text:
[11:45:53][D][EHMTXv2:098]: empty slot
[11:45:53][D][EHMTXv2:1464]: on_empty_queue trigger
[11:45:53][D][EHMTXv2:2398]: free_screen: found by endtime 0
[11:45:53][D][EHMTXv2:2196]: clock_screen_color lifetime: 0 screen_time: 10 red: 240 green: 240 blue: 240
[11:45:53][D][EHMTXv2:107]: queue: clock for: 10.0 sec
[11:45:53][D][EHMTXv2:1113]: oldest queue element is: 0/1
[11:45:53][D][EHMTXv2:107]: queue: clock for: 10.0 sec
[11:45:53][D][EHMTXv2:046]: ON_NEXT_CLOCK.
```
### Test
- [x] Code has been compiled for framework arduino, uploaded and executed without problems on a Seeed Studio XIAO ESP32S3.
- [x] Code has been compiled for framework esp-idf, uploaded and executed without problems on a Seeed Studio XIAO ESP32S3.
