### PR TITLE
Add the new cpu_frequency option to retain 240Mhz

### DIFF
--- a/install/ulanzi-easy.yaml
+++ b/install/ulanzi-easy.yaml
@@ -2,6 +2,7 @@ substitutions:
   devicename: ulanzi
   friendly_name: EspHoMaTriXv2
   board: esp32dev
+  cpu_frequency: 240MHz
   # Pin definition from https://github.com/aptonline/PixelIt_Ulanzi
   battery_pin: GPIO34
   ldr_pin: GPIO35
@@ -74,6 +75,7 @@ esphome:
 
 esp32:
   board: "$board"
+  cpu_frequency: $cpu_frequency
   framework:
     advanced:
       ignore_efuse_custom_mac: true

--- a/tests/esp32-arduino.yaml
+++ b/tests/esp32-arduino.yaml
@@ -29,6 +29,7 @@ esphome:
 
 esp32:
   board: esp32dev
+  cpu_frequency: 240MHz
 
 font:
   - file: ehmtx.ttf

--- a/tests/esp32-idf-features.yaml
+++ b/tests/esp32-idf-features.yaml
@@ -28,6 +28,7 @@ esphome:
 
 esp32:
   board: esp32dev
+  cpu_frequency: 240MHz
   framework:
     type: esp-idf
     version: recommended

--- a/tests/esp32-idf.yaml
+++ b/tests/esp32-idf.yaml
@@ -28,6 +28,7 @@ esphome:
 
 esp32:
   board: esp32dev
+  cpu_frequency: 240MHz
   framework:
     type: esp-idf
     version: recommended


### PR DESCRIPTION
I just ran across this from a change in 2025.5.0: https://github.com/esphome/esphome/pull/8542 

> NOTE: a side-effect of this PR is that the default CPU frequency for Arduino becomes 160MHz, rather than the 240MHz value baked into the Arduino core. ESP-IDF default was already 160.

A breaking change note is [pending](https://github.com/esphome/esphome-docs/pull/5013) and wasn't obvious from the [original changelog](https://esphome.io/changelog/2025.5.0).  Running at ~67% speed, it seems to affect timings for things like `blend_steps` but is much more noticeable for some addressable lambda effects I've added. 

You can now also verify the setting through the [debug component](https://esphome.io/components/debug.html).