### PR TITLE
Fix `wildcard` bug for `del_screen` does not yet work with icon names containing a `screen_id`

### DIFF
--- a/components/ehmtxv2/EHMTX.cpp
+++ b/components/ehmtxv2/EHMTX.cpp
@@ -1869,8 +1869,9 @@ register_service(&EHMTX::hide_lindicator, "hide_lindicator");
       {
         bool force = true;
         std::string ic = get_icon_name(icon_name);
-        std::string id = get_screen_id(icon_name);
+        std::string id = icon_name.find("|") != std::string::npos ? get_screen_id(icon_name) : ic;
         ESP_LOGD(TAG, "del_screen: %s -> icon: %s id: %s in position: %s mode: %d", icon_name.c_str(), ic.c_str(), id.c_str(), this->queue[i]->icon_name.c_str(), mode);
+
         if ((mode == MODE_ICON_SCREEN) ||
             (mode == MODE_ICON_CLOCK) ||
             (mode == MODE_ICON_DATE) ||


### PR DESCRIPTION
https://github.com/lubeda/EspHoMaTriXv2/issues/291#issuecomment-3020208452