### PR TITLE
2025.10.3: Fix for ESPHOME_F without Captive Portal or WEB Server

### DIFF
--- a/components/ehmtxv2/EHMTX.h
+++ b/components/ehmtxv2/EHMTX.h
@@ -2,6 +2,7 @@
 #define EHMTX_H
 #include "esphome.h"
 #include "esphome/components/time/real_time_clock.h"
+#include "esphome/components/web_server_base/web_server_base.h"
 
 #if defined USE_Fireplugin 
   #if defined CONFIG_IDF_TARGET_ESP32 || defined CONFIG_IDF_TARGET_ESP32C3 || defined CONFIG_IDF_TARGET_ESP32S3

--- a/components/ehmtxv2/__init__.py
+++ b/components/ehmtxv2/__init__.py
@@ -20,7 +20,7 @@ from urllib.parse import urlparse
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ["display", "light"]
-AUTO_LOAD = ["ehmtxv2", "json", "image", "animation"]
+AUTO_LOAD = ["ehmtxv2", "json", "image", "animation", "web_server_base"]
 MAXFRAMES = 110
 MAXICONS = 100
 ICONWIDTH = 8


### PR DESCRIPTION
* 2025.10.3: Fix for ESPHOME_F without Captive Portal or WEB Server
* 2025.10.3: Add `web_server_base` auto load for ESPHOME_F