### PR TITLE
Fix calendar icon day number alignment issue when icon is set to 9 pixels

### DIFF
--- a/components/ehmtxv2/EHMTX_queue.cpp
+++ b/components/ehmtxv2/EHMTX_queue.cpp
@@ -793,7 +793,14 @@ namespace esphome
               // To the center, without leading 0
               case 5:
                 x_left = (l_width < 5) ? 5 - l_width : 0;
-                x_right = 4;
+                if (this->config_->icon_to_9 == 1 || this->config_->icon_to_9 == 3)
+                {
+                  x_right = 5;
+                }
+                else
+                {
+                  x_right = 4;
+                }
                 break;
               // Left to center, Right to edge
               case 2:


### PR DESCRIPTION
Adjust the positioning of the right number in calendar icon to ensure it aligns correctly in the center if setting icon_to_9 is set to either 1 or 3.