### PR TITLE
Fix distorted animated icons on ESPHome 2026.4.0 (#331)

### DIFF
--- a/components/ehmtxv2/__init__.py
+++ b/components/ehmtxv2/__init__.py
@@ -13,7 +13,7 @@ import esphome.codegen as cg
 from esphome.const import CONF_BLUE, CONF_GREEN, CONF_RED, CONF_RESIZE, CONF_FILE, CONF_ID, CONF_BRIGHTNESS, CONF_RAW_DATA_ID,  CONF_TIME, CONF_TRIGGER_ID
 from esphome.core import CORE, HexInt
 from esphome.cpp_generator import RawExpression
-from esphome.components.image import CONF_ALPHA_CHANNEL, IMAGE_TYPE
+from esphome.components.image import CONF_CHROMA_KEY, IMAGE_TYPE
 
 from urllib.parse import urlparse
 
@@ -484,7 +484,15 @@ async def to_code(config):
             yaml_string += F"\"{conf[CONF_ID]}\","
 
             dither = Image.Dither.NONE
-            transparency = CONF_ALPHA_CHANNEL
+            # Use CHROMA_KEY instead of ALPHA_CHANNEL: on ESPHome 2026.4.0 the
+            # appended-alpha layout is incompatible with Animation frame indexing
+            # (Animation::update_data_start_ advances by w*h*2 per frame, ignoring
+            # the alpha block). Chroma-key stores the transparent-pixel marker
+            # inline (0x0020), so each frame is exactly w*h*2 bytes and the C++
+            # Animation class can index into it correctly on every ESPHome
+            # version. 8x8 pixel-art icons use binary transparency anyway —
+            # fixes issue #331.            
+            transparency = CONF_CHROMA_KEY
             invert_alpha = False
 
             total_rows = height * frames
@@ -495,6 +503,12 @@ async def to_code(config):
                 dither,
                 invert_alpha,
             )
+            # ESPHome 2026.4.0 flipped the default RGB565 byte order to little-
+            # endian, but the C++ Image::get_rgb565_pixel_ decoder still reads
+            # big-endian. set_big_endian exists on every ESPHome release that
+            # supports EHMTXv2; no-op on <2026.4.0 where BE was already default.
+            if hasattr(encoder, "set_big_endian"):
+                encoder.set_big_endian(True)
             for frame_index in range(frames):
                 image.seek(frame_index)
                 pixels = encoder.convert(image.resize((width, height)), path).getdata()


### PR DESCRIPTION
## Root cause

ESPHome 2026.4.0 reworked `ImageRGB565` in two ways that together break every RGB565-with-transparency icon produced by EHMTXv2:

1. **Default byte order flipped** from big-endian to little-endian for the Python encoder, but the C++ `Image::get_rgb565_pixel_` decoder still reads big-endian. Every pixel comes out byte-swapped.
2. **Alpha channel moved** from per-pixel interleaved to an appended block via a new `encoder.end_image()` call. For **multi-frame animations** the new layout is actually broken end-to-end: `write_image()` calls `end_image()` per frame, each call appends the entire growing alpha buffer, and `Animation::update_data_start_()` advances `data_start_` by only `w*h*2` bytes (the RGB-only frame size). The decoder then reads "alpha" bytes that fall inside the next frame's RGB data — producing the pixel-soup reported in the issue.

## Fix

Fixes #331.
Two small changes in `components/ehmtxv2/__init__.py`:

- **Call `encoder.set_big_endian(True)`** so RGB565 bytes match what the C++ decoder reads. Guarded with `hasattr` for backwards compatibility; no-op on older ESPHome where BE was already the default.
- **Switch icon transparency from `ALPHA_CHANNEL` to `CHROMA_KEY`.** Chroma-key stores the transparent-pixel marker (`0x0020`) inline in the RGB565 stream, so every frame is exactly `w*h*2` bytes and `Animation` frame indexing works correctly on every ESPHome version. The only semantic change is that alpha values between 1 and 127 now render fully transparent instead of partially opaque — 8x8 pixel-art icons (LaMetric style) are binary-alpha in practice, so this matches real usage.

## Testing

Verified locally on ESPHome 2026.4.0 against a physical Ulanzi display with both static and animated icons — previously distorted animations now render correctly. Byte-level verification of the encoder output confirms each frame is `w*h*2` bytes and the chroma-key sentinel `0x0020` is placed at transparent pixels in big-endian form.

## Compatibility

- **ESPHome 2026.4.0+**: fixes distorted icons.
- **ESPHome 2025.10.x – 2026.3.x**: unchanged output. `set_big_endian(True)` matches the old default; `CHROMA_KEY` worked identically here.
- **ESPHome <2025.10**: `set_big_endian` didn't exist yet; `hasattr` guard makes this a no-op and byte order defaulted to BE anyway.

## Notes

- Original PR: https://github.com/lubeda/EspHoMaTriXv2/pull/332
- No user-facing config change needed.
