### PR TITLE
ESPHome 2026.4.1: `little-endian` byte order for images

### DIFF
--- a/components/ehmtxv2/__init__.py
+++ b/components/ehmtxv2/__init__.py
@@ -484,14 +484,6 @@ async def to_code(config):
             yaml_string += F"\"{conf[CONF_ID]}\","
 
             dither = Image.Dither.NONE
-            # Use CHROMA_KEY instead of ALPHA_CHANNEL: on ESPHome 2026.4.0 the
-            # appended-alpha layout is incompatible with Animation frame indexing
-            # (Animation::update_data_start_ advances by w*h*2 per frame, ignoring
-            # the alpha block). Chroma-key stores the transparent-pixel marker
-            # inline (0x0020), so each frame is exactly w*h*2 bytes and the C++
-            # Animation class can index into it correctly on every ESPHome
-            # version. 8x8 pixel-art icons use binary transparency anyway —
-            # fixes issue #331.            
             transparency = CONF_CHROMA_KEY
             invert_alpha = False
 
@@ -503,12 +495,7 @@ async def to_code(config):
                 dither,
                 invert_alpha,
             )
-            # ESPHome 2026.4.0 flipped the default RGB565 byte order to little-
-            # endian, but the C++ Image::get_rgb565_pixel_ decoder still reads
-            # big-endian. set_big_endian exists on every ESPHome release that
-            # supports EHMTXv2; no-op on <2026.4.0 where BE was already default.
-            if hasattr(encoder, "set_big_endian"):
-                encoder.set_big_endian(True)
+            encoder.set_big_endian(False)
             for frame_index in range(frames):
                 image.seek(frame_index)
                 pixels = encoder.convert(image.resize((width, height)), path).getdata()


### PR DESCRIPTION
Fix for https://github.com/lubeda/EspHoMaTriXv2/issues/334 and https://github.com/andrewjswan/pixel-clock/issues/76