### PR TITLE
Add cron schedule to GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
   pull_request:
+  schedule:
+    - cron: '0 6 * * 4'
 
 jobs:
   build-stable:


### PR DESCRIPTION
Add a scheduled job to run every Thursday at 6 AM.